### PR TITLE
Update placeholder credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,10 +120,12 @@ Passen Sie die Datei `backend/.env` an Ihre Umgebung an:
 PORT=5000
 DB_HOST=localhost
 DB_USER=bvmw_user
-DB_PASSWORD=IhrSicheresPasswort
+DB_PASSWORD=changeme
 DB_NAME=buerokratieabbau
-JWT_SECRET=IhrGeheimesJWTToken
+JWT_SECRET=changeme
 ```
+
+**Wichtig:** Ersetzen Sie die Platzhalter `changeme` in `DB_PASSWORD` und `JWT_SECRET` durch sichere, individuelle Werte.
 
 ### MySQL-Setup
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -7,11 +7,11 @@ PORT=5000
 # Datenbank-Konfiguration
 DB_HOST=localhost
 DB_USER=bvmw_user
-DB_PASSWORD=BvmwSecurePassword123
+DB_PASSWORD=changeme
 DB_NAME=buerokratieabbau
 
 # JWT-Konfiguration
-JWT_SECRET=BvmwSecretToken2025
+JWT_SECRET=changeme
 
 # Weitere Konfigurationen (für zukünftige Erweiterungen)
 # SALESFORCE_CLIENT_ID=


### PR DESCRIPTION
## Summary
- adjust `.env.example` to use obvious fake values
- show placeholder credentials in README
- remind readers to provide secure credentials

## Testing
- `npm test` in `backend` *(fails: no test specified)*
- `CI=true npm test -- --watchAll=false --passWithNoTests` in `frontend`


------
https://chatgpt.com/codex/tasks/task_b_687a1e620d408323a83fe4892a1a296d