### PR TITLE
Add configurable CORS origins

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -3,6 +3,8 @@
 
 # Server-Konfiguration
 PORT=5000
+# Comma-separated list of allowed origins for CORS
+ALLOWED_ORIGINS=http://localhost:3000
 
 # Datenbank-Konfiguration
 DB_HOST=localhost

--- a/backend/app.js
+++ b/backend/app.js
@@ -1,5 +1,4 @@
 const express = require('express');
-const cors = require('cors');
 const helmet = require('helmet');
 require('dotenv').config();
 
@@ -7,7 +6,6 @@ const app = express();
 
 // Middleware
 app.use(helmet());
-app.use(cors());
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
 

--- a/backend/server.js
+++ b/backend/server.js
@@ -1,5 +1,22 @@
 const app = require('./app');
+const cors = require('cors');
+require('dotenv').config();
 const PORT = process.env.PORT || 5000;
+
+const allowedOrigins = (process.env.ALLOWED_ORIGINS || '')
+  .split(',')
+  .map((origin) => origin.trim())
+  .filter(Boolean);
+
+if (allowedOrigins.length > 0) {
+  app.use(
+    cors({
+      origin: allowedOrigins,
+    })
+  );
+} else {
+  app.use(cors());
+}
 
 app.listen(PORT, () => {
   console.log(`Server läuft auf Port ${PORT}`);


### PR DESCRIPTION
## Summary
- remove default CORS setup from `app.js`
- allow configuration of allowed origins in `server.js`
- document `ALLOWED_ORIGINS` env var in `.env.example`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_687a223c19f4832392f218219ccf1b16