### PR TITLE
Document votes extension and enforce table

### DIFF
--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -46,6 +46,9 @@ EXIT;
 #### Schema importieren
 ```bash
 mysql -u bvmw_user -p buerokratieabbau < backend/database/schema.sql
+
+# Erweiterung für das Bewertungssystem einspielen
+mysql -u bvmw_user -p buerokratieabbau < database_votes_extension.sql
 ```
 
 ### 3. Backend starten

--- a/README.md
+++ b/README.md
@@ -32,8 +32,11 @@ npm install
 # Passen Sie die Werte in der .env-Datei an Ihre Umgebung an
 
 # Datenbank einrichten
-# Führen Sie das SQL-Script aus
+# Basisschema importieren
 mysql -u BENUTZERNAME -p < database/schema.sql
+
+# Erweiterung für das Bewertungssystem (legt die Tabelle `votes` an)
+mysql -u BENUTZERNAME -p buerokratieabbau < ../database_votes_extension.sql
 
 # Server starten
 npm run dev
@@ -144,6 +147,9 @@ FLUSH PRIVILEGES;
 3. Importieren Sie das Schema:
 ```bash
 mysql -u bvmw_user -p buerokratieabbau < backend/database/schema.sql
+
+# Erweiterung für das Bewertungssystem einspielen
+mysql -u bvmw_user -p buerokratieabbau < database_votes_extension.sql
 ```
 
 ## API-Endpunkte

--- a/backend/config/db.js
+++ b/backend/config/db.js
@@ -11,5 +11,21 @@ const pool = mysql.createPool({
   queueLimit: 0
 });
 
+// Sicherstellen, dass die Tabelle 'votes' vorhanden ist
+if (process.env.NODE_ENV !== 'test') {
+  (async () => {
+    try {
+      const [rows] = await pool.query("SHOW TABLES LIKE 'votes'");
+      if (rows.length === 0) {
+        console.error("Die Tabelle 'votes' wurde nicht gefunden. Bitte 'database_votes_extension.sql' ausführen.");
+        process.exit(1);
+      }
+    } catch (err) {
+      console.error("Fehler bei der Prüfung der Tabelle 'votes':", err);
+      process.exit(1);
+    }
+  })();
+}
+
 module.exports = pool;
 


### PR DESCRIPTION
## Summary
- document how to import `database_votes_extension.sql`
- verify at startup that the `votes` table exists

## Testing
- `npm test` in `backend`
- `CI=true npm test` in `frontend`

------
https://chatgpt.com/codex/tasks/task_b_687a233aff4c8323a3d9e04454375564