### PR TITLE
Add comments API

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ npm install
 # Basisschema importieren
 mysql -u BENUTZERNAME -p < database/schema.sql
 
+# Das Basisschema legt auch die Tabelle `comments` an
+
 # Erweiterung für das Bewertungssystem (legt die Tabelle `votes` an)
 mysql -u BENUTZERNAME -p buerokratieabbau < ../database_votes_extension.sql
 
@@ -148,6 +150,8 @@ FLUSH PRIVILEGES;
 ```bash
 mysql -u bvmw_user -p buerokratieabbau < backend/database/schema.sql
 
+# Enthält auch die Tabelle `comments`
+
 # Erweiterung für das Bewertungssystem einspielen
 mysql -u bvmw_user -p buerokratieabbau < database_votes_extension.sql
 ```
@@ -164,6 +168,10 @@ mysql -u bvmw_user -p buerokratieabbau < database_votes_extension.sql
 - `GET /api/reports/:id` - Eine Meldung nach ID abrufen
 - `GET /api/reports/category/:categoryId` - Meldungen nach Kategorie filtern
 - `GET /api/reports/search/:query` - Meldungen durchsuchen
+
+### Kommentare
+- `GET /api/reports/:id/comments` - Kommentare zu einer Meldung abrufen
+- `POST /api/reports/:id/comments` - Kommentar zu einer Meldung erstellen (nur Moderator/Admin)
 
 ## Roadmap
 

--- a/backend/app.js
+++ b/backend/app.js
@@ -16,10 +16,12 @@ app.set('trust proxy', true);
 const categoriesRoutes = require('./routes/categories');
 const reportsRoutes = require('./routes/reports');
 const votesRoutes = require('./routes/votes');
+const commentsRoutes = require('./routes/comments');
 
 app.use('/api/categories', categoriesRoutes);
 app.use('/api/reports', reportsRoutes);
 app.use('/api/votes', votesRoutes);
+app.use('/api/reports/:id/comments', commentsRoutes);
 
 // Basis-Route
 app.get('/', (req, res) => {

--- a/backend/database/schema.sql
+++ b/backend/database/schema.sql
@@ -53,6 +53,18 @@ CREATE TABLE feedback (
   FOREIGN KEY (user_id) REFERENCES users(id)
 );
 
+-- Kommentare zu Meldungen
+CREATE TABLE comments (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  report_id INT NOT NULL,
+  user_id INT NOT NULL,
+  law_reference VARCHAR(255),
+  text TEXT NOT NULL,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  FOREIGN KEY (report_id) REFERENCES reports(id) ON DELETE CASCADE,
+  FOREIGN KEY (user_id) REFERENCES users(id)
+);
+
 -- Initiale Kategorien einfügen
 INSERT INTO categories (name, description) VALUES
 ('Steuer', 'Steuerliche Vorschriften und Meldepflichten'),

--- a/backend/middleware/auth.js
+++ b/backend/middleware/auth.js
@@ -1,0 +1,29 @@
+const jwt = require('jsonwebtoken');
+
+function authenticateJWT(req, res, next) {
+  const authHeader = req.headers['authorization'] || '';
+  const token = authHeader.split(' ')[1];
+
+  if (!token) {
+    return res.status(401).json({ message: 'Auth Token fehlt' });
+  }
+
+  try {
+    const decoded = jwt.verify(token, process.env.JWT_SECRET);
+    req.user = decoded;
+    next();
+  } catch (err) {
+    return res.status(401).json({ message: 'Ungültiger Token' });
+  }
+}
+
+function authorizeRoles(roles) {
+  return (req, res, next) => {
+    if (!req.user || !roles.includes(req.user.role)) {
+      return res.status(403).json({ message: 'Nicht autorisiert' });
+    }
+    next();
+  };
+}
+
+module.exports = { authenticateJWT, authorizeRoles };

--- a/backend/routes/comments.js
+++ b/backend/routes/comments.js
@@ -1,0 +1,47 @@
+const express = require('express');
+const router = express.Router({ mergeParams: true });
+const db = require('../config/db');
+const { body, validationResult } = require('express-validator');
+const { authenticateJWT, authorizeRoles } = require('../middleware/auth');
+
+// Kommentare zu einer Meldung abrufen
+router.get('/', async (req, res) => {
+  try {
+    const [rows] = await db.query(
+      'SELECT * FROM comments WHERE report_id = ? ORDER BY created_at DESC',
+      [req.params.id]
+    );
+    res.json(rows);
+  } catch (error) {
+    console.error('Fehler beim Abrufen der Kommentare:', error);
+    res.status(500).json({ message: 'Serverfehler beim Abrufen der Kommentare' });
+  }
+});
+
+// Kommentar erstellen
+router.post(
+  '/',
+  authenticateJWT,
+  authorizeRoles(['moderator', 'admin']),
+  [body('text').notEmpty().withMessage('Text ist erforderlich').trim(), body('law_reference').optional().trim()],
+  async (req, res) => {
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      return res.status(400).json({ message: 'Validierungsfehler', errors: errors.array() });
+    }
+
+    try {
+      const { text, law_reference } = req.body;
+      const [result] = await db.query(
+        'INSERT INTO comments (report_id, user_id, law_reference, text) VALUES (?, ?, ?, ?)',
+        [req.params.id, req.user.id, law_reference || null, text]
+      );
+      res.status(201).json({ id: result.insertId, report_id: parseInt(req.params.id), user_id: req.user.id, law_reference: law_reference || null, text });
+    } catch (error) {
+      console.error('Fehler beim Erstellen des Kommentars:', error);
+      res.status(500).json({ message: 'Serverfehler beim Erstellen des Kommentars' });
+    }
+  }
+);
+
+module.exports = router;

--- a/backend/routes/reports.js
+++ b/backend/routes/reports.js
@@ -27,7 +27,8 @@ router.get('/', async (req, res) => {
   try {
     const [rows] = await db.query(`
       SELECT r.*, c.name as category_name,
-             COALESCE(v.vote_count, 0) as vote_count
+             COALESCE(v.vote_count, 0) as vote_count,
+             EXISTS (SELECT 1 FROM comments WHERE report_id = r.id) AS has_comments
       FROM reports r 
       LEFT JOIN categories c ON r.category_id = c.id 
       LEFT JOIN (

--- a/backend/tests/comments.test.js
+++ b/backend/tests/comments.test.js
@@ -1,0 +1,55 @@
+const request = require('supertest');
+const jwt = require('jsonwebtoken');
+const app = require('../app');
+
+jest.mock('../config/db', () => ({
+  query: jest.fn()
+}));
+
+const db = require('../config/db');
+
+beforeAll(() => {
+  process.env.JWT_SECRET = 'testsecret';
+});
+
+describe('POST /api/reports/:id/comments', () => {
+  it('allows moderator to create comment', async () => {
+    const token = jwt.sign({ id: 1, role: 'moderator' }, process.env.JWT_SECRET);
+    db.query.mockResolvedValueOnce([{ insertId: 1 }]);
+
+    const res = await request(app)
+      .post('/api/reports/1/comments')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ text: 'Hallo' });
+
+    expect(res.statusCode).toBe(201);
+  });
+
+  it('rejects user role', async () => {
+    const token = jwt.sign({ id: 1, role: 'user' }, process.env.JWT_SECRET);
+    const res = await request(app)
+      .post('/api/reports/1/comments')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ text: 'Hallo' });
+
+    expect(res.statusCode).toBe(403);
+  });
+
+  it('rejects without token', async () => {
+    const res = await request(app)
+      .post('/api/reports/1/comments')
+      .send({ text: 'Hallo' });
+
+    expect(res.statusCode).toBe(401);
+  });
+});
+
+describe('GET /api/reports/:id/comments', () => {
+  it('returns comments', async () => {
+    db.query.mockResolvedValueOnce([[{ id: 1, text: 'Test' }]]);
+
+    const res = await request(app).get('/api/reports/1/comments');
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual([{ id: 1, text: 'Test' }]);
+  });
+});


### PR DESCRIPTION
## Summary
- add `comments` table to the base schema
- support posting and fetching comments for reports via new router
- extend report list query with `has_comments`
- mount comments router in app
- document comments table and endpoints
- test comment creation and retrieval

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_687a301cd8f4832395d4bfe2b7d8f01c