### PR TITLE
Add auth routes and JWT middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,13 @@ mysql -u bvmw_user -p buerokratieabbau < database_votes_extension.sql
 - `GET /api/reports/:id/comments` - Kommentare zu einer Meldung abrufen
 - `POST /api/reports/:id/comments` - Kommentar zu einer Meldung erstellen (nur Moderator/Admin)
 
+### Authentifizierung
+- `POST /api/auth/register` - Benutzer registrieren und JWT erhalten
+- `POST /api/auth/login` - Mit E-Mail und Passwort anmelden
+
+Senden Sie das ausgegebene Token bei geschützten Anfragen im Header:
+`Authorization: Bearer <TOKEN>`
+
 ## Roadmap
 
 1. **MVP (Aktuelle Version)**

--- a/backend/app.js
+++ b/backend/app.js
@@ -17,11 +17,13 @@ const categoriesRoutes = require('./routes/categories');
 const reportsRoutes = require('./routes/reports');
 const votesRoutes = require('./routes/votes');
 const commentsRoutes = require('./routes/comments');
+const authRoutes = require('./routes/auth');
 
 app.use('/api/categories', categoriesRoutes);
 app.use('/api/reports', reportsRoutes);
 app.use('/api/votes', votesRoutes);
 app.use('/api/reports/:id/comments', commentsRoutes);
+app.use('/api/auth', authRoutes);
 
 // Basis-Route
 app.get('/', (req, res) => {

--- a/backend/middleware/auth.js
+++ b/backend/middleware/auth.js
@@ -1,6 +1,6 @@
 const jwt = require('jsonwebtoken');
 
-function authenticateJWT(req, res, next) {
+function verifyToken(req, res, next) {
   const authHeader = req.headers['authorization'] || '';
   const token = authHeader.split(' ')[1];
 
@@ -10,20 +10,24 @@ function authenticateJWT(req, res, next) {
 
   try {
     const decoded = jwt.verify(token, process.env.JWT_SECRET);
-    req.user = decoded;
+    req.user = { id: decoded.id, role: decoded.role };
     next();
   } catch (err) {
     return res.status(401).json({ message: 'Ungültiger Token' });
   }
 }
 
-function authorizeRoles(roles) {
+function requireRole(role) {
+  const levels = { user: 1, moderator: 2, admin: 3 };
   return (req, res, next) => {
-    if (!req.user || !roles.includes(req.user.role)) {
+    if (!req.user) {
+      return res.status(401).json({ message: 'Nicht autorisiert' });
+    }
+    if ((levels[req.user.role] || 0) < (levels[role] || 0)) {
       return res.status(403).json({ message: 'Nicht autorisiert' });
     }
     next();
   };
 }
 
-module.exports = { authenticateJWT, authorizeRoles };
+module.exports = { verifyToken, requireRole };

--- a/backend/routes/auth.js
+++ b/backend/routes/auth.js
@@ -1,0 +1,78 @@
+const express = require('express');
+const router = express.Router();
+const db = require('../config/db');
+const bcrypt = require('bcrypt');
+const jwt = require('jsonwebtoken');
+const { body, validationResult } = require('express-validator');
+
+// Registrierung
+router.post(
+  '/register',
+  [
+    body('email').isEmail().withMessage('Ungültige Email'),
+    body('password').isLength({ min: 6 }).withMessage('Passwort zu kurz'),
+    body('name').optional().trim(),
+    body('company').optional().trim(),
+  ],
+  async (req, res) => {
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      return res.status(400).json({ message: 'Validierungsfehler', errors: errors.array() });
+    }
+
+    const { email, password, name, company } = req.body;
+    try {
+      const [existing] = await db.query('SELECT id FROM users WHERE email = ?', [email]);
+      if (existing.length > 0) {
+        return res.status(400).json({ message: 'E-Mail bereits registriert' });
+      }
+
+      const passwordHash = await bcrypt.hash(password, 10);
+      const [result] = await db.query(
+        'INSERT INTO users (email, password_hash, name, company) VALUES (?, ?, ?, ?)',
+        [email, passwordHash, name || null, company || null]
+      );
+
+      const token = jwt.sign({ id: result.insertId, role: 'user' }, process.env.JWT_SECRET);
+      res.status(201).json({ token });
+    } catch (err) {
+      console.error('Fehler bei der Registrierung:', err);
+      res.status(500).json({ message: 'Serverfehler bei der Registrierung' });
+    }
+  }
+);
+
+// Login
+router.post(
+  '/login',
+  [body('email').isEmail(), body('password').notEmpty()],
+  async (req, res) => {
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      return res.status(400).json({ message: 'Validierungsfehler', errors: errors.array() });
+    }
+
+    const { email, password } = req.body;
+    try {
+      const [rows] = await db.query('SELECT * FROM users WHERE email = ?', [email]);
+      if (rows.length === 0) {
+        return res.status(401).json({ message: 'Ungültige Anmeldedaten' });
+      }
+
+      const user = rows[0];
+      const match = await bcrypt.compare(password, user.password_hash);
+      if (!match) {
+        return res.status(401).json({ message: 'Ungültige Anmeldedaten' });
+      }
+
+      await db.query('UPDATE users SET last_login = NOW() WHERE id = ?', [user.id]);
+      const token = jwt.sign({ id: user.id, role: user.role }, process.env.JWT_SECRET);
+      res.json({ token });
+    } catch (err) {
+      console.error('Fehler beim Login:', err);
+      res.status(500).json({ message: 'Serverfehler beim Login' });
+    }
+  }
+);
+
+module.exports = router;

--- a/backend/routes/comments.js
+++ b/backend/routes/comments.js
@@ -2,7 +2,7 @@ const express = require('express');
 const router = express.Router({ mergeParams: true });
 const db = require('../config/db');
 const { body, validationResult } = require('express-validator');
-const { authenticateJWT, authorizeRoles } = require('../middleware/auth');
+const { verifyToken, requireRole } = require('../middleware/auth');
 
 // Kommentare zu einer Meldung abrufen
 router.get('/', async (req, res) => {
@@ -21,8 +21,8 @@ router.get('/', async (req, res) => {
 // Kommentar erstellen
 router.post(
   '/',
-  authenticateJWT,
-  authorizeRoles(['moderator', 'admin']),
+  verifyToken,
+  requireRole('moderator'),
   [body('text').notEmpty().withMessage('Text ist erforderlich').trim(), body('law_reference').optional().trim()],
   async (req, res) => {
     const errors = validationResult(req);

--- a/backend/tests/auth.test.js
+++ b/backend/tests/auth.test.js
@@ -1,0 +1,53 @@
+const request = require('supertest');
+const bcrypt = require('bcrypt');
+const app = require('../app');
+
+jest.mock('../config/db', () => ({
+  query: jest.fn()
+}));
+
+const db = require('../config/db');
+
+beforeAll(() => {
+  process.env.JWT_SECRET = 'testsecret';
+});
+
+describe('POST /api/auth/register', () => {
+  it('registers new user and returns token', async () => {
+    db.query.mockResolvedValueOnce([[]]); // check existing
+    db.query.mockResolvedValueOnce([{ insertId: 1 }]); // insert
+
+    const res = await request(app)
+      .post('/api/auth/register')
+      .send({ email: 'test@example.com', password: 'secret' });
+
+    expect(res.statusCode).toBe(201);
+    expect(res.body.token).toBeDefined();
+  });
+});
+
+describe('POST /api/auth/login', () => {
+  it('logs in and returns token', async () => {
+    const hash = await bcrypt.hash('secret', 10);
+    db.query.mockResolvedValueOnce([[{ id: 1, password_hash: hash, role: 'user' }]]); // select
+    db.query.mockResolvedValueOnce([{}]); // update last login
+
+    const res = await request(app)
+      .post('/api/auth/login')
+      .send({ email: 'test@example.com', password: 'secret' });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.token).toBeDefined();
+  });
+
+  it('rejects invalid password', async () => {
+    const hash = await bcrypt.hash('secret', 10);
+    db.query.mockResolvedValueOnce([[{ id: 1, password_hash: hash, role: 'user' }]]); // select
+
+    const res = await request(app)
+      .post('/api/auth/login')
+      .send({ email: 'test@example.com', password: 'wrong' });
+
+    expect(res.statusCode).toBe(401);
+  });
+});


### PR DESCRIPTION
## Summary
- implement `auth.js` routes for registration and login
- use JWT verification and role guard helpers in middleware
- protect comment creation with `requireRole('moderator')`
- register auth routes in the app
- document token usage in README
- add tests for auth endpoints

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_687a32958acc832393df21d601073b5d