### PR TITLE
Add comment section with moderation features

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -4,6 +4,7 @@ import styled from 'styled-components';
 import ReportForm from './components/ReportForm';
 import ReportList from './components/ReportList';
 import ReportDetail from './components/ReportDetail';
+import { AuthProvider } from './AuthContext';
 
 const AppContainer = styled.div`
   font-family: Arial, sans-serif;
@@ -117,8 +118,9 @@ const Copyright = styled.div`
 
 function App() {
   return (
-    <Router>
-      <AppContainer>
+    <AuthProvider>
+      <Router>
+        <AppContainer>
         <Header>
           <HeaderContent>
             <Logo>
@@ -169,6 +171,7 @@ function App() {
         </Footer>
       </AppContainer>
     </Router>
+  </AuthProvider>
   );
 }
 

--- a/frontend/src/AuthContext.js
+++ b/frontend/src/AuthContext.js
@@ -1,0 +1,16 @@
+import React, { createContext, useContext, useState } from 'react';
+
+const AuthContext = createContext({ user: null, setUser: () => {} });
+
+export const AuthProvider = ({ children, initialUser = null }) => {
+  const [user, setUser] = useState(initialUser);
+  return (
+    <AuthContext.Provider value={{ user, setUser }}>
+      {children}
+    </AuthContext.Provider>
+  );
+};
+
+export const useAuth = () => useContext(AuthContext);
+
+export default AuthContext;

--- a/frontend/src/components/CommentSection.js
+++ b/frontend/src/components/CommentSection.js
@@ -1,0 +1,133 @@
+import React, { useEffect, useState } from 'react';
+import axios from 'axios';
+import styled from 'styled-components';
+import { useAuth } from '../AuthContext';
+
+const Section = styled.div`
+  margin-top: 40px;
+`;
+
+const CommentBox = styled.div`
+  border-bottom: 1px solid #eee;
+  padding: 10px 0;
+`;
+
+const LawReference = styled.span`
+  display: block;
+  color: #777;
+  font-size: 14px;
+`;
+
+const Form = styled.form`
+  margin-top: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+`;
+
+const TextArea = styled.textarea`
+  padding: 10px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  min-height: 80px;
+`;
+
+const Input = styled.input`
+  padding: 10px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+`;
+
+const Button = styled.button`
+  background-color: #003E7E;
+  color: white;
+  border: none;
+  padding: 10px 20px;
+  border-radius: 4px;
+  cursor: pointer;
+`;
+
+const CommentSection = ({ reportId }) => {
+  const { user } = useAuth();
+  const [comments, setComments] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [text, setText] = useState('');
+  const [lawRef, setLawRef] = useState('');
+
+  useEffect(() => {
+    const fetchComments = async () => {
+      try {
+        const response = await axios.get(
+          `${process.env.REACT_APP_API_BASE_URL}/api/reports/${reportId}/comments`
+        );
+        setComments(response.data);
+      } catch (err) {
+        console.error('Fehler beim Laden der Kommentare:', err);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    if (reportId) {
+      fetchComments();
+    }
+  }, [reportId]);
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    if (!text.trim()) return;
+
+    try {
+      const token = localStorage.getItem('authToken');
+      const response = await axios.post(
+        `${process.env.REACT_APP_API_BASE_URL}/api/reports/${reportId}/comments`,
+        { text, law_reference: lawRef || null },
+        { headers: { Authorization: token ? `Bearer ${token}` : '' } }
+      );
+      setComments([response.data, ...comments]);
+      setText('');
+      setLawRef('');
+    } catch (err) {
+      console.error('Fehler beim Erstellen des Kommentars:', err);
+    }
+  };
+
+  if (loading) return <div>Kommentare werden geladen...</div>;
+
+  return (
+    <Section>
+      <h3>Kommentare</h3>
+      {comments.length === 0 ? (
+        <div>Noch keine Kommentare</div>
+      ) : (
+        comments.map((c) => (
+          <CommentBox key={c.id}>
+            <div>{c.text}</div>
+            {c.law_reference && (
+              <LawReference>{c.law_reference}</LawReference>
+            )}
+          </CommentBox>
+        ))
+      )}
+
+      {(user?.role === 'moderator' || user?.role === 'admin') && (
+        <Form onSubmit={handleSubmit}>
+          <TextArea
+            placeholder="Kommentar eingeben"
+            value={text}
+            onChange={(e) => setText(e.target.value)}
+            required
+          />
+          <Input
+            placeholder="Gesetzesbezug (optional)"
+            value={lawRef}
+            onChange={(e) => setLawRef(e.target.value)}
+          />
+          <Button type="submit">Absenden</Button>
+        </Form>
+      )}
+    </Section>
+  );
+};
+
+export default CommentSection;

--- a/frontend/src/components/ReportDetail.js
+++ b/frontend/src/components/ReportDetail.js
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import axios from 'axios';
 import styled from 'styled-components';
+import CommentSection from './CommentSection';
 
 const DetailContainer = styled.div`
   max-width: 900px;
@@ -321,6 +322,7 @@ const ReportDetail = () => {
             {voteStatus.voteCount} {voteStatus.voteCount === 1 ? 'Person ist' : 'Personen sind'} auch betroffen
           </VoteCount>
         </VotingSection>
+        <CommentSection reportId={id} />
       </ReportCard>
     </DetailContainer>
   );

--- a/frontend/src/components/ReportList.js
+++ b/frontend/src/components/ReportList.js
@@ -159,6 +159,10 @@ const VoteCount = styled.span`
   font-weight: bold;
 `;
 
+const CommentIndicator = styled.span`
+  margin-left: 5px;
+`;
+
 const NoResults = styled.div`
   text-align: center;
   padding: 40px;
@@ -295,6 +299,9 @@ const ReportList = () => {
                 <VoteCount>
                   👍 {report.vote_count || 0}
                 </VoteCount>
+                {report.has_comments && (
+                  <CommentIndicator title="Kommentare vorhanden">💬</CommentIndicator>
+                )}
               </ReportStats>
             </ReportMeta>
           </ReportCard>

--- a/frontend/src/components/__tests__/CommentSection.test.js
+++ b/frontend/src/components/__tests__/CommentSection.test.js
@@ -1,0 +1,49 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import axios from 'axios';
+import CommentSection from '../CommentSection';
+import { AuthProvider } from '../../AuthContext';
+
+jest.mock('axios', () => ({
+  __esModule: true,
+  default: {
+    get: jest.fn(),
+    post: jest.fn(),
+  },
+}));
+
+beforeEach(() => {
+  process.env.REACT_APP_API_BASE_URL = '';
+});
+
+test('renders comments from api', async () => {
+  axios.get.mockResolvedValueOnce({ data: [{ id: 1, text: 'Hallo', law_reference: '§1' }] });
+  render(
+    <AuthProvider initialUser={{ role: 'user' }}>
+      <CommentSection reportId={1} />
+    </AuthProvider>
+  );
+  await waitFor(() => screen.getByText('Hallo'));
+  expect(screen.getByText('§1')).toBeInTheDocument();
+});
+
+test('shows form for moderators', async () => {
+  axios.get.mockResolvedValueOnce({ data: [] });
+  render(
+    <AuthProvider initialUser={{ role: 'moderator' }}>
+      <CommentSection reportId={1} />
+    </AuthProvider>
+  );
+  await waitFor(() => screen.getByText('Noch keine Kommentare'));
+  expect(screen.getByPlaceholderText('Kommentar eingeben')).toBeInTheDocument();
+});
+
+test('hides form for regular users', async () => {
+  axios.get.mockResolvedValueOnce({ data: [] });
+  render(
+    <AuthProvider initialUser={{ role: 'user' }}>
+      <CommentSection reportId={1} />
+    </AuthProvider>
+  );
+  await waitFor(() => screen.getByText('Noch keine Kommentare'));
+  expect(screen.queryByPlaceholderText('Kommentar eingeben')).toBeNull();
+});

--- a/frontend/src/components/__tests__/ReportList.test.js
+++ b/frontend/src/components/__tests__/ReportList.test.js
@@ -1,0 +1,39 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import axios from 'axios';
+import ReportList from '../ReportList';
+jest.mock('../CategorySelect', () => () => <div />);
+
+jest.mock('axios', () => ({
+  __esModule: true,
+  default: { get: jest.fn() },
+}));
+
+beforeEach(() => {
+  process.env.REACT_APP_API_BASE_URL = '';
+});
+
+test('shows comment indicator when has_comments is true', async () => {
+  axios.get.mockResolvedValueOnce({ data: [
+    {
+      id: 1,
+      title: 'Test',
+      description: 'Desc',
+      created_at: '2023-01-01',
+      category_id: 1,
+      category_name: 'Cat',
+      vote_count: 0,
+      has_comments: true,
+    },
+  ] });
+
+  render(
+    <MemoryRouter>
+      <ReportList />
+    </MemoryRouter>
+  );
+  await waitFor(() => expect(screen.queryByText('Meldungen werden geladen...')).not.toBeInTheDocument());
+  expect(screen.getByTitle('Kommentare vorhanden')).toBeInTheDocument();
+  expect(screen.getByText('Test')).toBeInTheDocument();
+});


### PR DESCRIPTION
## Summary
- introduce `AuthProvider` context for user role checks
- add `CommentSection` with moderator submission form
- show comment indicator in report list
- embed comments in report detail view
- test new comment functionality and indicator

## Testing
- `CI=true npm test -- -u`

------
https://chatgpt.com/codex/tasks/task_b_687a34173ebc832387606a2cc9335e31