### PR TITLE
Use API_BASE constant for axios

### DIFF
--- a/frontend/src/components/CategorySelect.js
+++ b/frontend/src/components/CategorySelect.js
@@ -2,6 +2,8 @@ import React, { useState, useEffect } from 'react';
 import axios from 'axios';
 import styled from 'styled-components';
 
+const API_BASE = process.env.REACT_APP_API_BASE_URL || '';
+
 const SelectContainer = styled.div`
   margin-bottom: 20px;
 `;
@@ -40,7 +42,7 @@ const CategorySelect = ({ value, onChange, required = false }) => {
   useEffect(() => {
     const fetchCategories = async () => {
       try {
-        const response = await axios.get(`${process.env.REACT_APP_API_BASE_URL}/api/categories`);
+        const response = await axios.get(`${API_BASE}/api/categories`);
         setCategories(response.data);
         setLoading(false);
       } catch (err) {

--- a/frontend/src/components/CommentSection.js
+++ b/frontend/src/components/CommentSection.js
@@ -3,6 +3,8 @@ import axios from 'axios';
 import styled from 'styled-components';
 import { useAuth } from '../AuthContext';
 
+const API_BASE = process.env.REACT_APP_API_BASE_URL || '';
+
 const Section = styled.div`
   margin-top: 40px;
 `;
@@ -58,7 +60,7 @@ const CommentSection = ({ reportId }) => {
     const fetchComments = async () => {
       try {
         const response = await axios.get(
-          `${process.env.REACT_APP_API_BASE_URL}/api/reports/${reportId}/comments`
+          `${API_BASE}/api/reports/${reportId}/comments`
         );
         setComments(response.data);
       } catch (err) {
@@ -80,7 +82,7 @@ const CommentSection = ({ reportId }) => {
     try {
       const token = localStorage.getItem('authToken');
       const response = await axios.post(
-        `${process.env.REACT_APP_API_BASE_URL}/api/reports/${reportId}/comments`,
+        `${API_BASE}/api/reports/${reportId}/comments`,
         { text, law_reference: lawRef || null },
         { headers: { Authorization: token ? `Bearer ${token}` : '' } }
       );

--- a/frontend/src/components/ReportDetail.js
+++ b/frontend/src/components/ReportDetail.js
@@ -4,6 +4,8 @@ import axios from 'axios';
 import styled from 'styled-components';
 import CommentSection from './CommentSection';
 
+const API_BASE = process.env.REACT_APP_API_BASE_URL || '';
+
 const DetailContainer = styled.div`
   max-width: 900px;
   margin: 0 auto;
@@ -177,7 +179,7 @@ const ReportDetail = () => {
   useEffect(() => {
     const fetchReport = async () => {
       try {
-        const response = await axios.get(`${process.env.REACT_APP_API_BASE_URL}/api/reports/${id}`);
+        const response = await axios.get(`${API_BASE}/api/reports/${id}`);
         setReport(response.data);
         setLoading(false);
       } catch (err) {
@@ -198,7 +200,7 @@ const ReportDetail = () => {
       if (!sessionId || !id) return;
 
       try {
-        const response = await axios.get(`${process.env.REACT_APP_API_BASE_URL}/api/votes/${id}/vote-status`, {
+        const response = await axios.get(`${API_BASE}/api/votes/${id}/vote-status`, {
           headers: { 'x-session-id': sessionId }
         });
         setVoteStatus(response.data);
@@ -217,7 +219,7 @@ const ReportDetail = () => {
     try {
       if (voteStatus.hasVoted) {
         // Bewertung entfernen
-        const response = await axios.delete(`${process.env.REACT_APP_API_BASE_URL}/api/votes/${id}/vote`, {
+        const response = await axios.delete(`${API_BASE}/api/votes/${id}/vote`, {
           headers: { 'x-session-id': sessionId }
         });
         setVoteStatus({
@@ -226,7 +228,7 @@ const ReportDetail = () => {
         });
       } else {
         // Bewertung hinzufügen
-        const response = await axios.post(`${process.env.REACT_APP_API_BASE_URL}/api/votes/${id}/vote`, {}, {
+        const response = await axios.post(`${API_BASE}/api/votes/${id}/vote`, {}, {
           headers: { 'x-session-id': sessionId }
         });
         setVoteStatus({

--- a/frontend/src/components/ReportList.js
+++ b/frontend/src/components/ReportList.js
@@ -4,6 +4,8 @@ import styled from 'styled-components';
 import { Link } from 'react-router-dom';
 import CategorySelect from './CategorySelect';
 
+const API_BASE = process.env.REACT_APP_API_BASE_URL || '';
+
 const ListContainer = styled.div`
   max-width: 1000px;
   margin: 0 auto;
@@ -198,7 +200,7 @@ const ReportList = () => {
   useEffect(() => {
     const fetchReports = async () => {
       try {
-        const response = await axios.get(`${process.env.REACT_APP_API_BASE_URL}/api/reports`);
+        const response = await axios.get(`${API_BASE}/api/reports`);
         setReports(response.data);
         setFilteredReports(response.data);
         setLoading(false);

--- a/frontend/src/components/__tests__/CategorySelect.test.js
+++ b/frontend/src/components/__tests__/CategorySelect.test.js
@@ -1,6 +1,7 @@
 import { render, screen, waitFor } from '@testing-library/react';
-import CategorySelect from '../CategorySelect';
 import axios from 'axios';
+
+let CategorySelect;
 
 jest.mock('axios', () => ({
   __esModule: true,
@@ -11,6 +12,8 @@ jest.mock('axios', () => ({
 
 beforeEach(() => {
   process.env.REACT_APP_API_BASE_URL = '';
+  jest.resetModules();
+  CategorySelect = require('../CategorySelect').default;
 });
 
 test('renders options from api', async () => {

--- a/frontend/src/components/__tests__/CommentSection.test.js
+++ b/frontend/src/components/__tests__/CommentSection.test.js
@@ -1,7 +1,8 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import axios from 'axios';
-import CommentSection from '../CommentSection';
 import { AuthProvider } from '../../AuthContext';
+
+let CommentSection;
 
 jest.mock('axios', () => ({
   __esModule: true,
@@ -13,6 +14,8 @@ jest.mock('axios', () => ({
 
 beforeEach(() => {
   process.env.REACT_APP_API_BASE_URL = '';
+  jest.resetModules();
+  CommentSection = require('../CommentSection').default;
 });
 
 test('renders comments from api', async () => {

--- a/frontend/src/components/__tests__/ReportList.test.js
+++ b/frontend/src/components/__tests__/ReportList.test.js
@@ -2,7 +2,8 @@ import React from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import axios from 'axios';
-import ReportList from '../ReportList';
+
+let ReportList;
 jest.mock('../CategorySelect', () => () => <div />);
 
 jest.mock('axios', () => ({
@@ -12,6 +13,8 @@ jest.mock('axios', () => ({
 
 beforeEach(() => {
   process.env.REACT_APP_API_BASE_URL = '';
+  jest.resetModules();
+  ReportList = require('../ReportList').default;
 });
 
 test('shows comment indicator when has_comments is true', async () => {


### PR DESCRIPTION
## Summary
- centralize API base URL in CategorySelect, ReportList, ReportDetail and CommentSection
- update axios calls to use API_BASE constant
- load components dynamically in tests so API_BASE can be set before import

## Testing
- `npm test` *(fails: `npm` not found)*

------
https://chatgpt.com/codex/tasks/task_b_687e2bb9ec7083238f0901664b337dd2