### PR TITLE
Add tests for reports and votes

### DIFF
--- a/backend/tests/reports.test.js
+++ b/backend/tests/reports.test.js
@@ -1,0 +1,45 @@
+const request = require('supertest');
+const app = require('../app');
+
+jest.mock('../config/db', () => ({
+  query: jest.fn(),
+}));
+
+const db = require('../config/db');
+
+describe('POST /api/reports', () => {
+  it('creates a new report', async () => {
+    db.query.mockResolvedValueOnce([[{ id: 1 }]]); // category exists
+    db.query.mockResolvedValueOnce([{ insertId: 42 }]); // insert
+    db.query.mockResolvedValueOnce([[{ id: 42, title: 'Test', description: 'Desc', category_name: 'Cat' }]]); // fetch
+
+    const res = await request(app).post('/api/reports').send({
+      title: 'Test',
+      description: 'Desc',
+      category_id: 1,
+    });
+
+    expect(res.statusCode).toBe(201);
+    expect(res.body.id).toBe(42);
+  });
+});
+
+describe('GET /api/reports', () => {
+  it('returns list of reports', async () => {
+    db.query.mockResolvedValueOnce([[{ id: 1, title: 'Test' }]]);
+
+    const res = await request(app).get('/api/reports');
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual([{ id: 1, title: 'Test' }]);
+  });
+});
+
+describe('GET /api/reports/:id', () => {
+  it('returns single report', async () => {
+    db.query.mockResolvedValueOnce([[{ id: 1, title: 'Test' }]]);
+
+    const res = await request(app).get('/api/reports/1');
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual({ id: 1, title: 'Test' });
+  });
+});

--- a/backend/tests/votes.test.js
+++ b/backend/tests/votes.test.js
@@ -1,0 +1,52 @@
+const request = require('supertest');
+const app = require('../app');
+
+jest.mock('../config/db', () => ({
+  query: jest.fn(),
+}));
+
+const db = require('../config/db');
+
+describe('POST /api/votes/:id/vote', () => {
+  it('adds a vote', async () => {
+    db.query.mockResolvedValueOnce([[{ id: 1 }]]); // report exists
+    db.query.mockResolvedValueOnce([[]]); // no existing vote
+    db.query.mockResolvedValueOnce([{}]); // insert
+    db.query.mockResolvedValueOnce([[{ count: 1 }]]); // count
+
+    const res = await request(app).post('/api/votes/1/vote');
+    expect(res.statusCode).toBe(200);
+    expect(res.body.voteCount).toBe(1);
+    expect(res.body.hasVoted).toBe(true);
+  });
+});
+
+describe('DELETE /api/votes/:id/vote', () => {
+  it('removes a vote', async () => {
+    db.query.mockResolvedValueOnce([{ affectedRows: 1 }]);
+    db.query.mockResolvedValueOnce([[{ count: 0 }]]);
+
+    const res = await request(app)
+      .delete('/api/votes/1/vote')
+      .set('x-session-id', 'abc');
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.voteCount).toBe(0);
+    expect(res.body.hasVoted).toBe(false);
+  });
+});
+
+describe('GET /api/votes/:id/vote-status', () => {
+  it('returns vote status', async () => {
+    db.query.mockResolvedValueOnce([[{ count: 2 }]]); // total
+    db.query.mockResolvedValueOnce([[{ id: 1 }]]); // user vote
+
+    const res = await request(app)
+      .get('/api/votes/1/vote-status')
+      .set('x-session-id', 'abc');
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.voteCount).toBe(2);
+    expect(res.body.hasVoted).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add Jest tests for reports CRUD endpoints
- add Jest tests for vote endpoints

## Testing
- `cd backend && npm test`

------
https://chatgpt.com/codex/tasks/task_b_687e2ea160848323b27e48ce0f396eb7