### PR TITLE
Use API_BASE constant in report form

### DIFF
--- a/frontend/src/components/ReportForm.js
+++ b/frontend/src/components/ReportForm.js
@@ -3,6 +3,8 @@ import { useFormik } from 'formik';
 import * as Yup from 'yup';
 import styled from 'styled-components';
 import axios from 'axios';
+
+const API_BASE = process.env.REACT_APP_API_BASE_URL || '';
 import CategorySelect from './CategorySelect';
 
 const isDev = process.env.NODE_ENV === 'development';
@@ -170,7 +172,7 @@ const ReportForm = () => {
       }
       
       try {
-        const response = await axios.post(`${process.env.REACT_APP_API_BASE_URL}/api/reports`, formData);
+        const response = await axios.post(`${API_BASE}/api/reports`, formData);
         if (isDev) {
           console.log('Antwort vom Server:', response.data);
         }

--- a/frontend/src/components/__tests__/ReportForm.test.js
+++ b/frontend/src/components/__tests__/ReportForm.test.js
@@ -1,0 +1,39 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import axios from 'axios';
+
+let ReportForm;
+
+jest.mock('axios', () => ({
+  __esModule: true,
+  default: {
+    post: jest.fn(),
+  },
+}));
+
+jest.mock('../CategorySelect', () => ({ value, onChange }) => (
+  <select data-testid="category-select" value={value} onChange={e => onChange(e.target.value)}>
+    <option value="">-- Bitte wählen --</option>
+    <option value="1">Category 1</option>
+  </select>
+));
+
+beforeEach(() => {
+  process.env.REACT_APP_API_BASE_URL = '/base';
+  jest.resetModules();
+  ReportForm = require('../ReportForm').default;
+});
+
+test('sends data to correct base url', async () => {
+  axios.post.mockResolvedValueOnce({ data: {} });
+  render(<ReportForm />);
+
+  await userEvent.type(screen.getByLabelText(/Titel/), 'Test');
+  await userEvent.type(screen.getByLabelText(/Beschreibung/), 'Desc');
+  await userEvent.selectOptions(screen.getByTestId('category-select'), '1');
+  await userEvent.click(screen.getByRole('button', { name: /absenden/i }));
+
+  await waitFor(() => expect(axios.post).toHaveBeenCalled());
+  expect(axios.post).toHaveBeenCalledWith('/base/api/reports', expect.any(Object));
+});


### PR DESCRIPTION
## Summary
- define `API_BASE` constant in `ReportForm`
- use `API_BASE` for submitting reports
- test ReportForm axios call

## Testing
- `CI=true npm test -- --watchAll=false` *(fails: Invalid hook call)*

------
https://chatgpt.com/codex/tasks/task_b_687e3133e6b083238be4222f7a81b4b2