### PR TITLE
Move CORS setup to app

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -1,5 +1,6 @@
 const express = require('express');
 const helmet = require('helmet');
+const cors = require('cors');
 require('dotenv').config();
 
 const app = express();
@@ -11,6 +12,22 @@ app.use(express.urlencoded({ extended: true }));
 
 // Trust proxy für korrekte IP-Adressen
 app.set('trust proxy', true);
+
+// CORS-Konfiguration
+const allowedOrigins = (process.env.ALLOWED_ORIGINS || '')
+  .split(',')
+  .map((origin) => origin.trim())
+  .filter(Boolean);
+
+if (allowedOrigins.length > 0) {
+  app.use(
+    cors({
+      origin: allowedOrigins,
+    })
+  );
+} else {
+  app.use(cors());
+}
 
 // Routen
 const categoriesRoutes = require('./routes/categories');

--- a/backend/server.js
+++ b/backend/server.js
@@ -1,22 +1,6 @@
 const app = require('./app');
-const cors = require('cors');
 require('dotenv').config();
 const PORT = process.env.PORT || 5000;
-
-const allowedOrigins = (process.env.ALLOWED_ORIGINS || '')
-  .split(',')
-  .map((origin) => origin.trim())
-  .filter(Boolean);
-
-if (allowedOrigins.length > 0) {
-  app.use(
-    cors({
-      origin: allowedOrigins,
-    })
-  );
-} else {
-  app.use(cors());
-}
 
 app.listen(PORT, () => {
   console.log(`Server läuft auf Port ${PORT}`);

--- a/backend/tests/cors.test.js
+++ b/backend/tests/cors.test.js
@@ -1,0 +1,16 @@
+const request = require('supertest');
+const app = require('../app');
+
+jest.mock('../config/db', () => ({
+  query: jest.fn(),
+}));
+
+const db = require('../config/db');
+
+describe('CORS headers', () => {
+  it('includes Access-Control-Allow-Origin header', async () => {
+    db.query.mockResolvedValueOnce([[]]);
+    const res = await request(app).get('/api/reports');
+    expect(res.headers['access-control-allow-origin']).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary
- configure CORS inside `app.js` with the same ALLOWED_ORIGINS logic
- simplify `server.js`
- add a regression test verifying CORS headers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_687e3826cbf08323a9d8f8b40aa9777d