### PR TITLE
Centralize API base constant

### DIFF
--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -1,0 +1,1 @@
+export const API_BASE = process.env.REACT_APP_API_BASE_URL || '';

--- a/frontend/src/components/CategorySelect.js
+++ b/frontend/src/components/CategorySelect.js
@@ -1,8 +1,8 @@
 import React, { useState, useEffect } from 'react';
 import axios from 'axios';
+import { API_BASE } from '../api';
 import styled from 'styled-components';
 
-const API_BASE = process.env.REACT_APP_API_BASE_URL || '';
 
 const SelectContainer = styled.div`
   margin-bottom: 20px;

--- a/frontend/src/components/CommentSection.js
+++ b/frontend/src/components/CommentSection.js
@@ -1,9 +1,9 @@
 import React, { useEffect, useState } from 'react';
 import axios from 'axios';
+import { API_BASE } from '../api';
 import styled from 'styled-components';
 import { useAuth } from '../AuthContext';
 
-const API_BASE = process.env.REACT_APP_API_BASE_URL || '';
 
 const Section = styled.div`
   margin-top: 40px;

--- a/frontend/src/components/ReportDetail.js
+++ b/frontend/src/components/ReportDetail.js
@@ -1,10 +1,10 @@
 import React, { useState, useEffect } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import axios from 'axios';
+import { API_BASE } from '../api';
 import styled from 'styled-components';
 import CommentSection from './CommentSection';
 
-const API_BASE = process.env.REACT_APP_API_BASE_URL || '';
 
 const DetailContainer = styled.div`
   max-width: 900px;

--- a/frontend/src/components/ReportForm.js
+++ b/frontend/src/components/ReportForm.js
@@ -3,8 +3,8 @@ import { useFormik } from 'formik';
 import * as Yup from 'yup';
 import styled from 'styled-components';
 import axios from 'axios';
+import { API_BASE } from '../api';
 
-const API_BASE = process.env.REACT_APP_API_BASE_URL || '';
 import CategorySelect from './CategorySelect';
 
 const isDev = process.env.NODE_ENV === 'development';

--- a/frontend/src/components/ReportList.js
+++ b/frontend/src/components/ReportList.js
@@ -1,10 +1,10 @@
 import React, { useState, useEffect } from 'react';
 import axios from 'axios';
+import { API_BASE } from '../api';
 import styled from 'styled-components';
 import { Link } from 'react-router-dom';
 import CategorySelect from './CategorySelect';
 
-const API_BASE = process.env.REACT_APP_API_BASE_URL || '';
 
 const ListContainer = styled.div`
   max-width: 1000px;

--- a/frontend/src/components/__tests__/CategorySelect.test.js
+++ b/frontend/src/components/__tests__/CategorySelect.test.js
@@ -10,9 +10,9 @@ jest.mock('axios', () => ({
   }
 }));
 
-beforeEach(() => {
-  process.env.REACT_APP_API_BASE_URL = '';
+ beforeEach(() => {
   jest.resetModules();
+  process.env.REACT_APP_API_BASE_URL = '';
   CategorySelect = require('../CategorySelect').default;
 });
 

--- a/frontend/src/components/__tests__/CommentSection.test.js
+++ b/frontend/src/components/__tests__/CommentSection.test.js
@@ -12,9 +12,9 @@ jest.mock('axios', () => ({
   },
 }));
 
-beforeEach(() => {
-  process.env.REACT_APP_API_BASE_URL = '';
+ beforeEach(() => {
   jest.resetModules();
+  process.env.REACT_APP_API_BASE_URL = '';
   CommentSection = require('../CommentSection').default;
 });
 

--- a/frontend/src/components/__tests__/ReportForm.test.js
+++ b/frontend/src/components/__tests__/ReportForm.test.js
@@ -19,9 +19,9 @@ jest.mock('../CategorySelect', () => ({ value, onChange }) => (
   </select>
 ));
 
-beforeEach(() => {
-  process.env.REACT_APP_API_BASE_URL = '/base';
+ beforeEach(() => {
   jest.resetModules();
+  process.env.REACT_APP_API_BASE_URL = '/base';
   ReportForm = require('../ReportForm').default;
 });
 

--- a/frontend/src/components/__tests__/ReportList.test.js
+++ b/frontend/src/components/__tests__/ReportList.test.js
@@ -11,9 +11,9 @@ jest.mock('axios', () => ({
   default: { get: jest.fn() },
 }));
 
-beforeEach(() => {
-  process.env.REACT_APP_API_BASE_URL = '';
+ beforeEach(() => {
   jest.resetModules();
+  process.env.REACT_APP_API_BASE_URL = '';
   ReportList = require('../ReportList').default;
 });
 


### PR DESCRIPTION
## Summary
- export `API_BASE` from `api.js`
- reference the new module across components
- reset modules before setting `REACT_APP_API_BASE_URL` in tests

## Testing
- `npm test --silent` *(fails: Cannot read properties of null (reading 'useState'))*

------
https://chatgpt.com/codex/tasks/task_b_687e39408a7c83238d51257f23839fd3