### PR TITLE
Add moderator registration endpoint

### DIFF
--- a/backend/tests/auth.test.js
+++ b/backend/tests/auth.test.js
@@ -1,5 +1,6 @@
 const request = require('supertest');
 const bcrypt = require('bcrypt');
+const jwt = require('jsonwebtoken');
 const app = require('../app');
 
 jest.mock('../config/db', () => ({
@@ -47,6 +48,42 @@ describe('POST /api/auth/login', () => {
     const res = await request(app)
       .post('/api/auth/login')
       .send({ email: 'test@example.com', password: 'wrong' });
+
+    expect(res.statusCode).toBe(401);
+  });
+});
+
+describe('POST /api/auth/register-moderator', () => {
+  it('allows admin to create moderator', async () => {
+    const token = jwt.sign({ id: 1, role: 'admin' }, process.env.JWT_SECRET);
+    db.query.mockResolvedValueOnce([[]]); // check existing
+    db.query.mockResolvedValueOnce([{ insertId: 2 }]); // insert
+
+    const res = await request(app)
+      .post('/api/auth/register-moderator')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ email: 'mod@example.com', password: 'secret' });
+
+    expect(res.statusCode).toBe(201);
+    expect(res.body.id).toBe(2);
+    const lastCall = db.query.mock.calls[db.query.mock.calls.length - 1];
+    expect(lastCall[1][4]).toBe('moderator');
+  });
+
+  it('rejects non-admin user', async () => {
+    const token = jwt.sign({ id: 1, role: 'user' }, process.env.JWT_SECRET);
+    const res = await request(app)
+      .post('/api/auth/register-moderator')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ email: 'mod@example.com', password: 'secret' });
+
+    expect(res.statusCode).toBe(403);
+  });
+
+  it('rejects without token', async () => {
+    const res = await request(app)
+      .post('/api/auth/register-moderator')
+      .send({ email: 'mod@example.com', password: 'secret' });
 
     expect(res.statusCode).toBe(401);
   });


### PR DESCRIPTION
## Summary
- implement `POST /api/auth/register-moderator` protected by admin role
- allow admins to create moderators by email/password/name/company
- test moderator registration authorization and role assignment

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_687f39745698832388c82d3b65d8b65f