### PR TITLE
Set default database host to 127.0.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,14 +174,14 @@ Passen Sie die Datei `backend/.env` an Ihre Umgebung an:
 ```
 PORT=5000
 ALLOWED_ORIGINS=http://localhost:3000
-DB_HOST=localhost
+DB_HOST=127.0.0.1
 DB_USER=bvmw_user
 DB_PASSWORD=changeme
 DB_NAME=buerokratieabbau
 JWT_SECRET=changeme
 ```
 
-**Wichtig:** Ersetzen Sie die Platzhalter `changeme` in `DB_PASSWORD` und `JWT_SECRET` durch sichere, individuelle Werte.
+**Wichtig:** Ersetzen Sie die Platzhalter `changeme` in `DB_PASSWORD` und `JWT_SECRET` durch sichere, individuelle Werte. Für `DB_HOST` wird `127.0.0.1` empfohlen, da dies zuverlässig auf die lokale Netzwerkschnittstelle zeigt und DNS- oder IPv6-Auflösungen von `localhost` umgeht.
 
 `ALLOWED_ORIGINS` legt fest, welche Urspruenge beim Aufruf der API zugelassen sind.
 Mehrere Eintraege koennen komma-getrennt angegeben werden.

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -7,7 +7,7 @@ PORT=5000
 ALLOWED_ORIGINS=http://localhost:3000
 
 # Datenbank-Konfiguration
-DB_HOST=localhost
+DB_HOST=127.0.0.1
 DB_USER=bvmw_user
 DB_PASSWORD=changeme
 DB_NAME=buerokratieabbau

--- a/backend/config/db.js
+++ b/backend/config/db.js
@@ -1,8 +1,11 @@
 const mysql = require('mysql2/promise');
 require('dotenv').config();
 
+const host = process.env.DB_HOST;
+const resolvedHost = !host || host === 'localhost' ? '127.0.0.1' : host;
+
 const pool = mysql.createPool({
-  host: process.env.DB_HOST,
+  host: resolvedHost,
   user: process.env.DB_USER,
   password: process.env.DB_PASSWORD,
   database: process.env.DB_NAME,


### PR DESCRIPTION
## Summary
- default the database host to 127.0.0.1 in the MySQL pool setup to avoid localhost resolution issues
- document the new default in the backend environment template and README
- explain in the README why using 127.0.0.1 is recommended

## Testing
- NODE_ENV=test DB_USER=dummy DB_PASSWORD=dummy DB_NAME=dummy npm start
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68d16b1e79708323aaf37a0ccb121388