### PR TITLE
feat(frontend): retheme primary color to red

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -8,6 +8,10 @@ import { AuthProvider, useAuth } from './AuthContext';
 import LoginPage from './pages/LoginPage';
 import RegisterModeratorPage from './pages/RegisterModeratorPage';
 
+const PRIMARY_RED = '#E30613';
+const PRIMARY_RED_DARK = '#b20510';
+const PRIMARY_RED_LIGHT = '#f9d8dc';
+
 const AppContainer = styled.div`
   font-family: Arial, sans-serif;
   color: #333;
@@ -41,7 +45,7 @@ const LogoImage = styled.img`
 const LogoText = styled.div`
   font-size: 20px;
   font-weight: bold;
-  color: #003E7E; /* BVMW Blau */
+  color: ${PRIMARY_RED};
 `;
 
 const Nav = styled.nav`
@@ -50,20 +54,50 @@ const Nav = styled.nav`
 `;
 
 const NavLink = styled(Link)`
-  color: #003E7E; /* BVMW Blau */
+  color: ${PRIMARY_RED};
   text-decoration: none;
   font-weight: bold;
   padding: 10px;
   border-radius: 4px;
-  transition: background-color 0.3s;
-  
+  transition: background-color 0.3s, color 0.3s;
+
   &:hover {
-    background-color: #f0f0f0;
+    background-color: ${PRIMARY_RED_LIGHT};
   }
-  
+
+  &:focus {
+    outline: 2px solid ${PRIMARY_RED_LIGHT};
+    outline-offset: 2px;
+  }
+
   &.active {
-    background-color: #003E7E; /* BVMW Blau */
-    color: white;
+    background-color: ${PRIMARY_RED};
+    color: #fff;
+  }
+
+  &.active:hover {
+    background-color: ${PRIMARY_RED_DARK};
+    color: #fff;
+  }
+`;
+
+const LogoutButton = styled.button`
+  color: #fff;
+  background-color: ${PRIMARY_RED};
+  border: none;
+  font-weight: bold;
+  padding: 10px 16px;
+  border-radius: 4px;
+  cursor: pointer;
+  transition: background-color 0.3s;
+
+  &:hover {
+    background-color: ${PRIMARY_RED_DARK};
+  }
+
+  &:focus {
+    outline: 2px solid ${PRIMARY_RED_LIGHT};
+    outline-offset: 2px;
   }
 `;
 
@@ -74,8 +108,8 @@ const Main = styled.main`
 `;
 
 const Footer = styled.footer`
-  background-color: #003E7E; /* BVMW Blau */
-  color: white;
+  background-color: ${PRIMARY_RED_DARK};
+  color: #fff;
   padding: 30px 0;
   margin-top: 60px;
 `;
@@ -97,16 +131,22 @@ const FooterSection = styled.div`
 const FooterTitle = styled.h3`
   margin-bottom: 15px;
   font-size: 18px;
+  color: ${PRIMARY_RED_LIGHT};
 `;
 
 const FooterLink = styled.a`
-  color: white;
+  color: #fff;
   text-decoration: none;
   display: block;
   margin-bottom: 8px;
-  
+
   &:hover {
-    text-decoration: underline;
+    color: ${PRIMARY_RED_LIGHT};
+  }
+
+  &:focus {
+    outline: 2px solid ${PRIMARY_RED_LIGHT};
+    outline-offset: 2px;
   }
 `;
 
@@ -129,7 +169,7 @@ function Navigation() {
         <NavLink to="/register-moderator">Moderator registrieren</NavLink>
       )}
       {user && (
-        <button onClick={logout}>Logout</button>
+        <LogoutButton type="button" onClick={logout}>Logout</LogoutButton>
       )}
     </Nav>
   );

--- a/frontend/src/components/CategorySelect.js
+++ b/frontend/src/components/CategorySelect.js
@@ -12,7 +12,7 @@ const Label = styled.label`
   display: block;
   margin-bottom: 8px;
   font-weight: bold;
-  color: #003E7E; /* BVMW Blau */
+  color: #E30613;
 `;
 
 const Select = styled.select`

--- a/frontend/src/components/CommentSection.js
+++ b/frontend/src/components/CommentSection.js
@@ -41,12 +41,22 @@ const Input = styled.input`
 `;
 
 const Button = styled.button`
-  background-color: #003E7E;
+  background-color: #E30613;
   color: white;
   border: none;
   padding: 10px 20px;
   border-radius: 4px;
   cursor: pointer;
+  transition: background-color 0.3s;
+
+  &:hover {
+    background-color: #b20510;
+  }
+
+  &:focus {
+    outline: 2px solid #f9d8dc;
+    outline-offset: 2px;
+  }
 `;
 
 const CommentSection = ({ reportId }) => {

--- a/frontend/src/components/ReportDetail.js
+++ b/frontend/src/components/ReportDetail.js
@@ -35,20 +35,20 @@ const ReportCard = styled.div`
   border-left: 5px solid ${props => {
     switch (props.category) {
       case 'Steuer': return '#E30613'; // BVMW Rot
-      case 'Dokumentationspflicht': return '#003E7E'; // BVMW Blau
+      case 'Dokumentationspflicht': return '#b20510'; // Dunkles Rot
       case 'Rechnungswesen': return '#58585A'; // BVMW Grau
       case 'Statistiken': return '#009FE3'; // Hellblau
       case 'Sozialversicherungen': return '#95C11F'; // Grün
       case 'Datenschutz': return '#FFED00'; // Gelb
       case 'Arbeitsschutz': return '#F39200'; // Orange
       case 'Branchenspezifisches': return '#A1006B'; // Lila
-      default: return '#003E7E'; // BVMW Blau als Standard
+      default: return '#E30613';
     }
   }};
 `;
 
 const ReportTitle = styled.h1`
-  color: #003E7E; /* BVMW Blau */
+  color: #E30613;
   margin-bottom: 20px;
   font-size: 28px;
   line-height: 1.3;
@@ -90,7 +90,7 @@ const MetaItem = styled.div`
 
 const MetaLabel = styled.span`
   font-weight: bold;
-  color: #003E7E; /* BVMW Blau */
+  color: #E30613;
   margin-bottom: 5px;
   font-size: 14px;
 `;
@@ -121,11 +121,16 @@ const VoteButton = styled.button`
   border-radius: 4px;
   cursor: pointer;
   transition: background-color 0.3s;
-  
+
   &:hover {
-    background-color: ${props => props.hasVoted ? '#45a049' : '#c00510'};
+    background-color: ${props => props.hasVoted ? '#45a049' : '#b20510'};
   }
-  
+
+  &:focus {
+    outline: 2px solid #f9d8dc;
+    outline-offset: 2px;
+  }
+
   &:disabled {
     background-color: #ccc;
     cursor: not-allowed;

--- a/frontend/src/components/ReportForm.js
+++ b/frontend/src/components/ReportForm.js
@@ -19,7 +19,7 @@ const FormContainer = styled.div`
 `;
 
 const FormTitle = styled.h2`
-  color: #003E7E; /* BVMW Blau */
+  color: #E30613;
   margin-bottom: 20px;
   font-size: 24px;
 `;
@@ -32,7 +32,7 @@ const Label = styled.label`
   display: block;
   margin-bottom: 8px;
   font-weight: bold;
-  color: #003E7E; /* BVMW Blau */
+  color: #E30613;
 `;
 
 const Input = styled.input`
@@ -79,7 +79,7 @@ const Checkbox = styled.input`
 `;
 
 const SubmitButton = styled.button`
-  background-color: #E30613; /* BVMW Rot */
+  background-color: #E30613;
   color: white;
   border: none;
   padding: 12px 20px;
@@ -88,11 +88,16 @@ const SubmitButton = styled.button`
   border-radius: 4px;
   cursor: pointer;
   transition: background-color 0.3s;
-  
+
   &:hover {
-    background-color: #c00510;
+    background-color: #b20510;
   }
-  
+
+  &:focus {
+    outline: 2px solid #f9d8dc;
+    outline-offset: 2px;
+  }
+
   &:disabled {
     background-color: #ccc;
     cursor: not-allowed;

--- a/frontend/src/components/ReportList.js
+++ b/frontend/src/components/ReportList.js
@@ -15,7 +15,7 @@ const ListContainer = styled.div`
 `;
 
 const ListTitle = styled.h2`
-  color: #003E7E; /* BVMW Blau */
+  color: #E30613;
   margin-bottom: 20px;
   font-size: 24px;
 `;
@@ -45,16 +45,21 @@ const SearchInput = styled.input`
 `;
 
 const SearchButton = styled.button`
-  background-color: #003E7E; /* BVMW Blau */
+  background-color: #E30613;
   color: white;
   border: none;
   padding: 10px 20px;
   font-size: 16px;
   border-radius: 4px;
   cursor: pointer;
-  
+
   &:hover {
-    background-color: #002a57;
+    background-color: #b20510;
+  }
+
+  &:focus {
+    outline: 2px solid #f9d8dc;
+    outline-offset: 2px;
   }
 `;
 
@@ -86,14 +91,14 @@ const ReportCard = styled.div`
   border-left: 5px solid ${props => {
     switch (props.category) {
       case 'Steuer': return '#E30613'; // BVMW Rot
-      case 'Dokumentationspflicht': return '#003E7E'; // BVMW Blau
+      case 'Dokumentationspflicht': return '#b20510'; // Dunkles Rot
       case 'Rechnungswesen': return '#58585A'; // BVMW Grau
       case 'Statistiken': return '#009FE3'; // Hellblau
       case 'Sozialversicherungen': return '#95C11F'; // Grün
       case 'Datenschutz': return '#FFED00'; // Gelb
       case 'Arbeitsschutz': return '#F39200'; // Orange
       case 'Branchenspezifisches': return '#A1006B'; // Lila
-      default: return '#003E7E'; // BVMW Blau als Standard
+      default: return '#E30613';
     }
   }};
   transition: transform 0.2s, box-shadow 0.2s;
@@ -105,17 +110,22 @@ const ReportCard = styled.div`
 `;
 
 const ReportTitle = styled.h3`
-  color: #003E7E; /* BVMW Blau */
+  color: #E30613;
   margin-bottom: 10px;
   font-size: 20px;
 `;
 
 const ReportTitleLink = styled(Link)`
-  color: #003E7E; /* BVMW Blau */
+  color: #E30613;
   text-decoration: none;
-  
+
   &:hover {
     text-decoration: underline;
+  }
+
+  &:focus {
+    outline: 2px solid #f9d8dc;
+    outline-offset: 2px;
   }
 `;
 

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -20,7 +20,8 @@ code {
 /* BVMW Farben */
 :root {
   --bvmw-red: #E30613;
-  --bvmw-blue: #003E7E;
+  --bvmw-primary: #E30613;
+  --bvmw-primary-dark: #b20510;
   --bvmw-gray: #58585A;
 }
 

--- a/frontend/src/pages/LoginPage.js
+++ b/frontend/src/pages/LoginPage.js
@@ -15,7 +15,7 @@ const Container = styled.div`
 `;
 
 const Title = styled.h2`
-  color: #003E7E;
+  color: #E30613;
   margin-bottom: 20px;
 `;
 
@@ -36,12 +36,22 @@ const Input = styled.input`
 `;
 
 const Button = styled.button`
-  background-color: #003E7E;
+  background-color: #E30613;
   color: white;
   border: none;
   padding: 10px 20px;
   border-radius: 4px;
   cursor: pointer;
+  transition: background-color 0.3s;
+
+  &:hover {
+    background-color: #b20510;
+  }
+
+  &:focus {
+    outline: 2px solid #f9d8dc;
+    outline-offset: 2px;
+  }
 `;
 
 const ErrorMsg = styled.div`

--- a/frontend/src/pages/RegisterModeratorPage.js
+++ b/frontend/src/pages/RegisterModeratorPage.js
@@ -13,7 +13,7 @@ const Container = styled.div`
 `;
 
 const Title = styled.h2`
-  color: #003E7E;
+  color: #E30613;
   margin-bottom: 20px;
 `;
 
@@ -34,12 +34,22 @@ const Input = styled.input`
 `;
 
 const Button = styled.button`
-  background-color: #003E7E;
+  background-color: #E30613;
   color: white;
   border: none;
   padding: 10px 20px;
   border-radius: 4px;
   cursor: pointer;
+  transition: background-color 0.3s;
+
+  &:hover {
+    background-color: #b20510;
+  }
+
+  &:focus {
+    outline: 2px solid #f9d8dc;
+    outline-offset: 2px;
+  }
 `;
 
 const Success = styled.div`


### PR DESCRIPTION
## Summary
- re-theme the navigation, footer, and shared layout elements to use the BVMW red palette with accessible focus states
- update report-related components plus comment interactions to replace the old blue accents with red hover and active treatments
- align authentication pages and CSS variables with the new red primary and dark accent shades for consistent contrast

## Testing
- CI=true npm --prefix frontend test -- --watch=false *(fails: existing Jest setup triggers invalid hook call warnings in component tests)*

------
https://chatgpt.com/codex/tasks/task_b_68d17eff3cc88323aea4710b6eaf5e82