### PR TITLE
Use Roboto Condensed for frontend typography

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -9,7 +9,7 @@ import LoginPage from './pages/LoginPage';
 import RegisterModeratorPage from './pages/RegisterModeratorPage';
 
 const AppContainer = styled.div`
-  font-family: Arial, sans-serif;
+  font-family: 'Roboto Condensed', sans-serif;
   color: #333;
 `;
 

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,8 +1,8 @@
+@import url('https://fonts.googleapis.com/css2?family=Roboto+Condensed:wght@300;400;500;700&display=swap');
+
 body {
   margin: 0;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
-    'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
-    sans-serif;
+  font-family: 'Roboto Condensed', sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   background-color: #f9f9f9;


### PR DESCRIPTION
## Summary
- import Roboto Condensed from Google Fonts and apply it to the global body styles
- align the AppContainer styled component to use the new Roboto Condensed font stack

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68d180bfc4f08323821a9d25baa6ba59