### PR TITLE
Add WZ category support to reports

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -35,12 +35,14 @@ const reportsRoutes = require('./routes/reports');
 const votesRoutes = require('./routes/votes');
 const commentsRoutes = require('./routes/comments');
 const authRoutes = require('./routes/auth');
+const wzCategoriesRoutes = require('./routes/wzCategories');
 
 app.use('/api/categories', categoriesRoutes);
 app.use('/api/reports', reportsRoutes);
 app.use('/api/votes', votesRoutes);
 app.use('/api/reports/:id/comments', commentsRoutes);
 app.use('/api/auth', authRoutes);
+app.use('/api/wz-categories', wzCategoriesRoutes);
 
 // Basis-Route
 app.get('/', (req, res) => {

--- a/backend/data/wzCategories.js
+++ b/backend/data/wzCategories.js
@@ -1,0 +1,23 @@
+module.exports = [
+  { key: 'A', name: 'Land- und Forstwirtschaft; Fischerei' },
+  { key: 'B', name: 'Bergbau und Gewinnung von Steinen und Erden' },
+  { key: 'C', name: 'Verarbeitendes Gewerbe / Herstellung von Waren' },
+  { key: 'D', name: 'Energieversorgung' },
+  { key: 'E', name: 'Wasserversorgung; Abwasser- und Abfallentsorgung und Beseitigung von Umweltverschmutzungen' },
+  { key: 'F', name: 'Baugewerbe' },
+  { key: 'G', name: 'Handel; Instandhaltung und Reparatur von Kraftfahrzeugen' },
+  { key: 'H', name: 'Verkehr und Lagerei' },
+  { key: 'I', name: 'Gastgewerbe / Beherbergung und Gastronomie' },
+  { key: 'J', name: 'Information und Kommunikation' },
+  { key: 'K', name: 'Finanz- und Versicherungsdienstleistungen' },
+  { key: 'L', name: 'Grundstücks- und Wohnungswesen' },
+  { key: 'M', name: 'Freiberufliche, wissenschaftliche und technische Dienstleistungen' },
+  { key: 'N', name: 'Sonstige wirtschaftliche Dienstleistungen' },
+  { key: 'O', name: 'Öffentliche Verwaltung, Verteidigung; Sozialversicherung' },
+  { key: 'P', name: 'Erziehung und Unterricht' },
+  { key: 'Q', name: 'Gesundheits- und Sozialwesen' },
+  { key: 'R', name: 'Kunst, Unterhaltung und Erholung' },
+  { key: 'S', name: 'Sonstige Dienstleistungen' },
+  { key: 'T', name: 'Private Haushalte mit Hauspersonal; Herstellung von Waren durch private Haushalte für den Eigenbedarf' },
+  { key: 'U', name: 'Exterritoriale Organisationen und Körperschaften' }
+];

--- a/backend/database/schema.sql
+++ b/backend/database/schema.sql
@@ -32,6 +32,7 @@ CREATE TABLE reports (
   reporter_name VARCHAR(100),
   reporter_company VARCHAR(100),
   reporter_email VARCHAR(255),
+  wz_category_key VARCHAR(10),
   is_anonymous BOOLEAN DEFAULT FALSE,
   status ENUM('pending', 'approved', 'rejected') DEFAULT 'pending',
   created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,

--- a/backend/routes/wzCategories.js
+++ b/backend/routes/wzCategories.js
@@ -1,0 +1,10 @@
+const express = require('express');
+const router = express.Router();
+
+const wzCategories = require('../data/wzCategories');
+
+router.get('/', (req, res) => {
+  res.json(wzCategories);
+});
+
+module.exports = router;

--- a/backend/tests/reports.test.js
+++ b/backend/tests/reports.test.js
@@ -11,35 +11,37 @@ describe('POST /api/reports', () => {
   it('creates a new report', async () => {
     db.query.mockResolvedValueOnce([[{ id: 1 }]]); // category exists
     db.query.mockResolvedValueOnce([{ insertId: 42 }]); // insert
-    db.query.mockResolvedValueOnce([[{ id: 42, title: 'Test', description: 'Desc', category_name: 'Cat' }]]); // fetch
+    db.query.mockResolvedValueOnce([[{ id: 42, title: 'Test', description: 'Desc', category_name: 'Cat', wz_category_key: 'A' }]]); // fetch
 
     const res = await request(app).post('/api/reports').send({
       title: 'Test',
       description: 'Desc',
       category_id: 1,
+      wz_category_key: 'a'
     });
 
     expect(res.statusCode).toBe(201);
     expect(res.body.id).toBe(42);
+    expect(db.query.mock.calls[1][1][9]).toBe('A');
   });
 });
 
 describe('GET /api/reports', () => {
   it('returns list of reports', async () => {
-    db.query.mockResolvedValueOnce([[{ id: 1, title: 'Test' }]]);
+    db.query.mockResolvedValueOnce([[{ id: 1, title: 'Test', wz_category_key: 'A' }]]);
 
     const res = await request(app).get('/api/reports');
     expect(res.statusCode).toBe(200);
-    expect(res.body).toEqual([{ id: 1, title: 'Test' }]);
+    expect(res.body).toEqual([{ id: 1, title: 'Test', wz_category_key: 'A' }]);
   });
 });
 
 describe('GET /api/reports/:id', () => {
   it('returns single report', async () => {
-    db.query.mockResolvedValueOnce([[{ id: 1, title: 'Test' }]]);
+    db.query.mockResolvedValueOnce([[{ id: 1, title: 'Test', wz_category_key: 'A' }]]);
 
     const res = await request(app).get('/api/reports/1');
     expect(res.statusCode).toBe(200);
-    expect(res.body).toEqual({ id: 1, title: 'Test' });
+    expect(res.body).toEqual({ id: 1, title: 'Test', wz_category_key: 'A' });
   });
 });

--- a/frontend/src/components/ReportForm.js
+++ b/frontend/src/components/ReportForm.js
@@ -6,6 +6,7 @@ import axios from 'axios';
 import { API_BASE } from '../api';
 
 import CategorySelect from './CategorySelect';
+import WZCategorySelect from './WZCategorySelect';
 
 const isDev = process.env.NODE_ENV === 'development';
 
@@ -122,6 +123,7 @@ const ReportForm = () => {
     title: Yup.string().required('Titel ist erforderlich'),
     description: Yup.string().required('Beschreibung ist erforderlich'),
     category_id: Yup.number().required('Kategorie ist erforderlich'),
+    wz_category_key: Yup.string().required('WZ-Oberkategorie ist erforderlich'),
     time_spent: Yup.number().min(0, 'Muss eine positive Zahl sein').nullable(),
     costs: Yup.number().min(0, 'Muss eine positive Zahl sein').nullable(),
     affected_employees: Yup.number().integer().min(0, 'Muss eine positive ganze Zahl sein').nullable(),
@@ -136,6 +138,7 @@ const ReportForm = () => {
       title: '',
       description: '',
       category_id: '',
+      wz_category_key: '',
       time_spent: '',
       costs: '',
       affected_employees: '',
@@ -154,6 +157,7 @@ const ReportForm = () => {
         title: values.title,
         description: values.description,
         category_id: Number(values.category_id),
+        wz_category_key: values.wz_category_key,
         time_spent: values.time_spent === '' ? null : Number(values.time_spent),
         costs: values.costs === '' ? null : Number(values.costs),
         affected_employees: values.affected_employees === '' ? null : Number(values.affected_employees),
@@ -231,6 +235,17 @@ const ReportForm = () => {
           />
           {formik.touched.category_id && formik.errors.category_id && (
             <ErrorText>{formik.errors.category_id}</ErrorText>
+          )}
+        </FormGroup>
+
+        <FormGroup>
+          <WZCategorySelect
+            value={formik.values.wz_category_key}
+            onChange={(value) => formik.setFieldValue('wz_category_key', value)}
+            required
+          />
+          {formik.touched.wz_category_key && formik.errors.wz_category_key && (
+            <ErrorText>{formik.errors.wz_category_key}</ErrorText>
           )}
         </FormGroup>
         

--- a/frontend/src/components/WZCategorySelect.js
+++ b/frontend/src/components/WZCategorySelect.js
@@ -1,0 +1,80 @@
+import React, { useEffect, useState } from 'react';
+import axios from 'axios';
+import styled from 'styled-components';
+import { API_BASE } from '../api';
+
+const SelectContainer = styled.div`
+  margin-bottom: 20px;
+`;
+
+const Label = styled.label`
+  display: block;
+  margin-bottom: 8px;
+  font-weight: bold;
+  color: #E30613;
+`;
+
+const Select = styled.select`
+  width: 100%;
+  padding: 10px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  font-size: 16px;
+
+  &:focus {
+    border-color: #E30613; /* BVMW Rot */
+    outline: none;
+  }
+`;
+
+const ErrorMessage = styled.div`
+  color: #E30613; /* BVMW Rot */
+  font-size: 14px;
+  margin-top: 5px;
+`;
+
+const WZCategorySelect = ({ value, onChange, required = false }) => {
+  const [wzCategories, setWzCategories] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    const fetchWzCategories = async () => {
+      try {
+        const response = await axios.get(`${API_BASE}/api/wz-categories`);
+        setWzCategories(response.data);
+      } catch (err) {
+        console.error('Fehler beim Laden der WZ-Kategorien:', err);
+        setError('WZ-Kategorien konnten nicht geladen werden.');
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchWzCategories();
+  }, []);
+
+  if (loading) return <div>WZ-Kategorien werden geladen...</div>;
+  if (error) return <ErrorMessage>{error}</ErrorMessage>;
+
+  return (
+    <SelectContainer>
+      <Label htmlFor="wz_category">WZ-Oberkategorie {required && '*'}</Label>
+      <Select
+        id="wz_category"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        required={required}
+      >
+        <option value="">-- Bitte wählen --</option>
+        {wzCategories.map((category) => (
+          <option key={category.key} value={category.key}>
+            {category.key} – {category.name}
+          </option>
+        ))}
+      </Select>
+    </SelectContainer>
+  );
+};
+
+export default WZCategorySelect;


### PR DESCRIPTION
## Summary
- extend the reports schema with a WZ category key and expose the available keys via a new endpoint
- validate, persist and return the WZ key for reports while updating backend tests
- add a frontend dropdown that loads WZ categories from the backend and submits the selection with the report form

## Testing
- npm test (backend)
- npm test -- --watchAll=false (frontend) *(fails: existing tests raise "Invalid hook call" in component tests)*

------
https://chatgpt.com/codex/tasks/task_b_68d192fbf31883239d20d0fb8f8d8a30