### PR TITLE
Restrict public report responses and add moderator endpoint

### DIFF
--- a/backend/tests/reports.test.js
+++ b/backend/tests/reports.test.js
@@ -1,4 +1,5 @@
 const request = require('supertest');
+const jwt = require('jsonwebtoken');
 const app = require('../app');
 
 jest.mock('../config/db', () => ({
@@ -7,11 +8,37 @@ jest.mock('../config/db', () => ({
 
 const db = require('../config/db');
 
+const basePublicReport = {
+  id: 1,
+  title: 'Test',
+  description: 'Desc',
+  category_id: 1,
+  category_name: 'Cat',
+  time_spent: null,
+  costs: null,
+  affected_employees: null,
+  wz_category_key: 'A',
+  is_anonymous: false,
+  status: 'pending',
+  created_at: '2024-01-01T00:00:00.000Z',
+  updated_at: null,
+  vote_count: 0,
+  has_comments: 0
+};
+
+beforeAll(() => {
+  process.env.JWT_SECRET = 'testsecret';
+});
+
+beforeEach(() => {
+  db.query.mockReset();
+});
+
 describe('POST /api/reports', () => {
-  it('creates a new report', async () => {
+  it('creates a new report and hides contact data', async () => {
     db.query.mockResolvedValueOnce([[{ id: 1 }]]); // category exists
     db.query.mockResolvedValueOnce([{ insertId: 42 }]); // insert
-    db.query.mockResolvedValueOnce([[{ id: 42, title: 'Test', description: 'Desc', category_name: 'Cat', wz_category_key: 'A' }]]); // fetch
+    db.query.mockResolvedValueOnce([[{ ...basePublicReport, id: 42 }]]); // fetch public fields
 
     const res = await request(app).post('/api/reports').send({
       title: 'Test',
@@ -21,27 +48,60 @@ describe('POST /api/reports', () => {
     });
 
     expect(res.statusCode).toBe(201);
-    expect(res.body.id).toBe(42);
+    expect(res.body).toEqual({ ...basePublicReport, id: 42 });
+    expect(res.body.reporter_email).toBeUndefined();
     expect(db.query.mock.calls[1][1][9]).toBe('A');
   });
 });
 
 describe('GET /api/reports', () => {
-  it('returns list of reports', async () => {
-    db.query.mockResolvedValueOnce([[{ id: 1, title: 'Test', wz_category_key: 'A' }]]);
+  it('returns list of sanitized reports', async () => {
+    db.query.mockResolvedValueOnce([[basePublicReport]]);
 
     const res = await request(app).get('/api/reports');
     expect(res.statusCode).toBe(200);
-    expect(res.body).toEqual([{ id: 1, title: 'Test', wz_category_key: 'A' }]);
+    expect(res.body).toEqual([basePublicReport]);
+    expect(res.body[0].reporter_name).toBeUndefined();
   });
 });
 
 describe('GET /api/reports/:id', () => {
-  it('returns single report', async () => {
-    db.query.mockResolvedValueOnce([[{ id: 1, title: 'Test', wz_category_key: 'A' }]]);
+  it('returns single sanitized report', async () => {
+    db.query.mockResolvedValueOnce([[basePublicReport]]);
 
     const res = await request(app).get('/api/reports/1');
     expect(res.statusCode).toBe(200);
-    expect(res.body).toEqual({ id: 1, title: 'Test', wz_category_key: 'A' });
+    expect(res.body).toEqual(basePublicReport);
+    expect(res.body.reporter_company).toBeUndefined();
+  });
+});
+
+describe('GET /api/reports/:id/confidential', () => {
+  it('requires authentication', async () => {
+    const res = await request(app).get('/api/reports/1/confidential');
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('returns confidential details for moderators', async () => {
+    const token = jwt.sign({ id: 5, role: 'moderator' }, process.env.JWT_SECRET);
+    const confidentialReport = {
+      ...basePublicReport,
+      reporter_name: 'Max Mustermann',
+      reporter_company: 'Beispiel GmbH',
+      reporter_email: 'max@example.com'
+    };
+    db.query.mockResolvedValueOnce([[confidentialReport]]);
+
+    const res = await request(app)
+      .get('/api/reports/1/confidential')
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.reporter_email).toBe('max@example.com');
+    expect(res.body).toMatchObject({
+      reporter_name: 'Max Mustermann',
+      reporter_company: 'Beispiel GmbH',
+      reporter_email: 'max@example.com'
+    });
   });
 });

--- a/frontend/src/components/ReportDetail.js
+++ b/frontend/src/components/ReportDetail.js
@@ -300,20 +300,15 @@ const ReportDetail = () => {
               <MetaValue>{report.affected_employees}</MetaValue>
             </MetaItem>
           )}
-          
-          {!report.is_anonymous && report.reporter_name && (
-            <MetaItem>
-              <MetaLabel>Gemeldet von</MetaLabel>
-              <MetaValue>{report.reporter_name}</MetaValue>
-            </MetaItem>
-          )}
-          
-          {!report.is_anonymous && report.reporter_company && (
-            <MetaItem>
-              <MetaLabel>Unternehmen</MetaLabel>
-              <MetaValue>{report.reporter_company}</MetaValue>
-            </MetaItem>
-          )}
+
+          <MetaItem>
+            <MetaLabel>Kontakthinweis</MetaLabel>
+            <MetaValue>
+              {report.is_anonymous
+                ? 'Diese Meldung wurde anonym eingereicht. Kontaktdaten liegen nicht vor.'
+                : 'Kontaktdaten sind nur für Moderationsteams sichtbar.'}
+            </MetaValue>
+          </MetaItem>
         </MetaSection>
         
         <VotingSection>

--- a/frontend/src/components/ReportList.js
+++ b/frontend/src/components/ReportList.js
@@ -260,6 +260,13 @@ const ReportDescription = styled.p`
   line-height: 1.5;
 `;
 
+const ContactNotice = styled.p`
+  margin: -5px 0 20px 0;
+  color: #666;
+  font-size: 13px;
+  font-style: italic;
+`;
+
 const ReportMeta = styled.div`
   display: flex;
   justify-content: space-between;
@@ -421,6 +428,7 @@ const ReportList = () => {
                 ? `${report.description.substring(0, 300)}...`
                 : report.description}
             </ReportDescription>
+            <ContactNotice>Kontaktdaten sind nur für Moderationsteams sichtbar.</ContactNotice>
             <ReportMeta>
               <ReportDate>Gemeldet am {formatDate(report.created_at)}</ReportDate>
               <ReportStats>


### PR DESCRIPTION
## Summary
- limit public report queries to non-sensitive columns and expose a moderator-only confidential endpoint
- adjust frontend report list and detail views to remove contact field usage and show an informational notice
- update backend Jest tests to reflect sanitized responses and cover the new secure endpoint

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68d25cd367948323bd374cb38b462115