### PR TITLE
Restrict public reports to approved status

### DIFF
--- a/backend/routes/reports.js
+++ b/backend/routes/reports.js
@@ -73,6 +73,7 @@ router.get('/', async (req, res) => {
         FROM votes
         GROUP BY report_id
       ) v ON r.id = v.report_id
+      WHERE r.status = 'approved'
       ORDER BY r.created_at DESC
     `);
     res.json(rows);
@@ -126,7 +127,7 @@ router.get('/:id', async (req, res) => {
         FROM votes
         GROUP BY report_id
       ) v ON r.id = v.report_id
-      WHERE r.id = ?
+      WHERE r.id = ? AND r.status = 'approved'
     `, [req.params.id]);
     
     if (rows.length === 0) {
@@ -188,8 +189,8 @@ router.post('/', reportValidationRules, async (req, res) => {
     const [result] = await db.query(
       `INSERT INTO reports
        (title, description, category_id, time_spent, costs, affected_employees,
-        reporter_name, reporter_company, reporter_email, wz_category_key, is_anonymous)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        reporter_name, reporter_company, reporter_email, wz_category_key, is_anonymous, status)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
       [
         title,
         description,
@@ -201,7 +202,8 @@ router.post('/', reportValidationRules, async (req, res) => {
         finalReporterCompany,
         finalReporterEmail,
         wz_category_key || null,
-        is_anonymous || false
+        is_anonymous || false,
+        'pending'
       ]
     );
 
@@ -245,7 +247,7 @@ router.get('/category/:categoryId', async (req, res) => {
         FROM votes
         GROUP BY report_id
       ) v ON r.id = v.report_id
-      WHERE r.category_id = ? 
+      WHERE r.category_id = ? AND r.status = 'approved'
       ORDER BY r.created_at DESC
     `, [req.params.categoryId]);
     
@@ -272,7 +274,7 @@ router.get('/search/:query', async (req, res) => {
         FROM votes
         GROUP BY report_id
       ) v ON r.id = v.report_id
-      WHERE r.title LIKE ? OR r.description LIKE ? 
+      WHERE (r.title LIKE ? OR r.description LIKE ?) AND r.status = 'approved'
       ORDER BY r.created_at DESC
     `, [searchQuery, searchQuery]);
     

--- a/backend/tests/reports.test.js
+++ b/backend/tests/reports.test.js
@@ -8,7 +8,7 @@ jest.mock('../config/db', () => ({
 
 const db = require('../config/db');
 
-const basePublicReport = {
+const baseApprovedReport = {
   id: 1,
   title: 'Test',
   description: 'Desc',
@@ -19,11 +19,16 @@ const basePublicReport = {
   affected_employees: null,
   wz_category_key: 'A',
   is_anonymous: false,
-  status: 'pending',
+  status: 'approved',
   created_at: '2024-01-01T00:00:00.000Z',
   updated_at: null,
   vote_count: 0,
   has_comments: 0
+};
+
+const basePendingReport = {
+  ...baseApprovedReport,
+  status: 'pending'
 };
 
 beforeAll(() => {
@@ -38,7 +43,7 @@ describe('POST /api/reports', () => {
   it('creates a new report and hides contact data', async () => {
     db.query.mockResolvedValueOnce([[{ id: 1 }]]); // category exists
     db.query.mockResolvedValueOnce([{ insertId: 42 }]); // insert
-    db.query.mockResolvedValueOnce([[{ ...basePublicReport, id: 42 }]]); // fetch public fields
+    db.query.mockResolvedValueOnce([[{ ...basePendingReport, id: 42 }]]); // fetch pending report
 
     const res = await request(app).post('/api/reports').send({
       title: 'Test',
@@ -48,31 +53,54 @@ describe('POST /api/reports', () => {
     });
 
     expect(res.statusCode).toBe(201);
-    expect(res.body).toEqual({ ...basePublicReport, id: 42 });
+    expect(res.body).toEqual({ ...basePendingReport, id: 42 });
     expect(res.body.reporter_email).toBeUndefined();
     expect(db.query.mock.calls[1][1][9]).toBe('A');
+    expect(db.query.mock.calls[1][1][11]).toBe('pending');
   });
 });
 
 describe('GET /api/reports', () => {
   it('returns list of sanitized reports', async () => {
-    db.query.mockResolvedValueOnce([[basePublicReport]]);
+    db.query.mockResolvedValueOnce([[baseApprovedReport]]);
 
     const res = await request(app).get('/api/reports');
     expect(res.statusCode).toBe(200);
-    expect(res.body).toEqual([basePublicReport]);
+    expect(res.body).toEqual([baseApprovedReport]);
     expect(res.body[0].reporter_name).toBeUndefined();
+  });
+
+  it('queries only approved reports', async () => {
+    db.query.mockResolvedValueOnce([[baseApprovedReport]]);
+
+    await request(app).get('/api/reports');
+    expect(db.query.mock.calls[0][0]).toContain("WHERE r.status = 'approved'");
   });
 });
 
 describe('GET /api/reports/:id', () => {
   it('returns single sanitized report', async () => {
-    db.query.mockResolvedValueOnce([[basePublicReport]]);
+    db.query.mockResolvedValueOnce([[baseApprovedReport]]);
 
     const res = await request(app).get('/api/reports/1');
     expect(res.statusCode).toBe(200);
-    expect(res.body).toEqual(basePublicReport);
+    expect(res.body).toEqual(baseApprovedReport);
     expect(res.body.reporter_company).toBeUndefined();
+  });
+
+  it('queries only approved report by id', async () => {
+    db.query.mockResolvedValueOnce([[baseApprovedReport]]);
+
+    await request(app).get('/api/reports/1');
+    expect(db.query.mock.calls[0][0]).toContain("WHERE r.id = ? AND r.status = 'approved'");
+    expect(db.query.mock.calls[0][1]).toEqual(['1']);
+  });
+
+  it('returns 404 for non-approved reports', async () => {
+    db.query.mockResolvedValueOnce([[]]);
+
+    const res = await request(app).get('/api/reports/1');
+    expect(res.statusCode).toBe(404);
   });
 });
 
@@ -85,7 +113,7 @@ describe('GET /api/reports/:id/confidential', () => {
   it('returns confidential details for moderators', async () => {
     const token = jwt.sign({ id: 5, role: 'moderator' }, process.env.JWT_SECRET);
     const confidentialReport = {
-      ...basePublicReport,
+      ...baseApprovedReport,
       reporter_name: 'Max Mustermann',
       reporter_company: 'Beispiel GmbH',
       reporter_email: 'max@example.com'
@@ -103,5 +131,25 @@ describe('GET /api/reports/:id/confidential', () => {
       reporter_company: 'Beispiel GmbH',
       reporter_email: 'max@example.com'
     });
+  });
+});
+
+describe('GET /api/reports/category/:categoryId', () => {
+  it('filters by category and approved status', async () => {
+    db.query.mockResolvedValueOnce([[baseApprovedReport]]);
+
+    await request(app).get('/api/reports/category/1');
+    expect(db.query.mock.calls[0][0]).toContain("WHERE r.category_id = ? AND r.status = 'approved'");
+    expect(db.query.mock.calls[0][1]).toEqual(['1']);
+  });
+});
+
+describe('GET /api/reports/search/:query', () => {
+  it('searches only approved reports', async () => {
+    db.query.mockResolvedValueOnce([[baseApprovedReport]]);
+
+    await request(app).get('/api/reports/search/test');
+    expect(db.query.mock.calls[0][0]).toContain("WHERE (r.title LIKE ? OR r.description LIKE ?) AND r.status = 'approved'");
+    expect(db.query.mock.calls[0][1]).toEqual(['%test%', '%test%']);
   });
 });


### PR DESCRIPTION
## Summary
- add approved-status filter to all public report queries and keep confidential endpoints unrestricted
- ensure new reports are inserted with an explicit pending status value
- expand report route tests to cover status filtering and verify SQL clauses

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68d25f7a8998832384ef872ccaa46fd0