### PR TITLE
Handle JWT expiration across backend and frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,9 +179,12 @@ DB_USER=bvmw_user
 DB_PASSWORD=changeme
 DB_NAME=buerokratieabbau
 JWT_SECRET=changeme
+JWT_EXPIRES_IN=24h
 ```
 
 **Wichtig:** Ersetzen Sie die Platzhalter `changeme` in `DB_PASSWORD` und `JWT_SECRET` durch sichere, individuelle Werte. Für `DB_HOST` wird `127.0.0.1` empfohlen, da dies zuverlässig auf die lokale Netzwerkschnittstelle zeigt und DNS- oder IPv6-Auflösungen von `localhost` umgeht.
+
+`JWT_EXPIRES_IN` legt fest, wie lange neu ausgestellte JSON Web Tokens gültig sind (Standard: 24 Stunden).
 
 `ALLOWED_ORIGINS` legt fest, welche Urspruenge beim Aufruf der API zugelassen sind.
 Mehrere Eintraege koennen komma-getrennt angegeben werden.

--- a/backend/middleware/auth.js
+++ b/backend/middleware/auth.js
@@ -13,6 +13,9 @@ function verifyToken(req, res, next) {
     req.user = { id: decoded.id, role: decoded.role };
     next();
   } catch (err) {
+    if (err.name === 'TokenExpiredError') {
+      return res.status(401).json({ message: 'Token abgelaufen' });
+    }
     return res.status(401).json({ message: 'Ungültiger Token' });
   }
 }

--- a/backend/routes/auth.js
+++ b/backend/routes/auth.js
@@ -6,6 +6,8 @@ const jwt = require('jsonwebtoken');
 const { body, validationResult } = require('express-validator');
 const { verifyToken, requireRole } = require('../middleware/auth');
 
+const tokenOptions = { expiresIn: process.env.JWT_EXPIRES_IN || '24h' };
+
 // Registrierung
 router.post(
   '/register',
@@ -34,7 +36,7 @@ router.post(
         [email, passwordHash, name || null, company || null]
       );
 
-      const token = jwt.sign({ id: result.insertId, role: 'user' }, process.env.JWT_SECRET);
+      const token = jwt.sign({ id: result.insertId, role: 'user' }, process.env.JWT_SECRET, tokenOptions);
       res.status(201).json({ token });
     } catch (err) {
       console.error('Fehler bei der Registrierung:', err);
@@ -109,7 +111,7 @@ router.post(
       }
 
       await db.query('UPDATE users SET last_login = NOW() WHERE id = ?', [user.id]);
-      const token = jwt.sign({ id: user.id, role: user.role }, process.env.JWT_SECRET);
+      const token = jwt.sign({ id: user.id, role: user.role }, process.env.JWT_SECRET, tokenOptions);
       res.json({ token });
     } catch (err) {
       console.error('Fehler beim Login:', err);

--- a/frontend/src/AuthContext.js
+++ b/frontend/src/AuthContext.js
@@ -1,32 +1,65 @@
-import React, { createContext, useContext, useState, useEffect } from 'react';
+import React, { createContext, useContext, useState, useEffect, useRef } from 'react';
 import jwtDecode from 'jwt-decode';
 
 const AuthContext = createContext({ user: null, login: () => {}, logout: () => {} });
 
 export const AuthProvider = ({ children, initialUser = null }) => {
   const [user, setUser] = useState(initialUser);
+  const logoutTimeoutRef = useRef(null);
+
+  const clearLogoutTimer = () => {
+    if (logoutTimeoutRef.current) {
+      clearTimeout(logoutTimeoutRef.current);
+      logoutTimeoutRef.current = null;
+    }
+  };
+
+  const logout = () => {
+    clearLogoutTimer();
+    localStorage.removeItem('authToken');
+    setUser(null);
+  };
+
+  const scheduleLogout = (exp) => {
+    clearLogoutTimer();
+    if (!exp) {
+      return;
+    }
+    const expiresInMs = exp * 1000 - Date.now();
+    if (expiresInMs <= 0) {
+      logout();
+      return;
+    }
+    logoutTimeoutRef.current = setTimeout(logout, expiresInMs);
+  };
 
   useEffect(() => {
     const token = localStorage.getItem('authToken');
     if (token) {
       try {
         const decoded = jwtDecode(token);
-        setUser({ role: decoded.role });
+        if (decoded.exp && decoded.exp * 1000 <= Date.now()) {
+          logout();
+        } else {
+          setUser({ role: decoded.role });
+          scheduleLogout(decoded.exp);
+        }
       } catch {
-        localStorage.removeItem('authToken');
+        logout();
       }
     }
+    return () => clearLogoutTimer();
   }, []);
 
   const login = (token) => {
     localStorage.setItem('authToken', token);
     const decoded = jwtDecode(token);
+    if (decoded.exp && decoded.exp * 1000 <= Date.now()) {
+      logout();
+      return;
+    }
     setUser({ role: decoded.role });
-  };
-
-  const logout = () => {
-    localStorage.removeItem('authToken');
-    setUser(null);
+    scheduleLogout(decoded.exp);
   };
 
   return (


### PR DESCRIPTION
## Summary
- configure backend JWT issuance to use a configurable expiration and document the environment variable
- improve middleware error handling for expired tokens and extend auth tests to cover expiry behaviour
- update the frontend auth context to detect and auto-logout expired tokens

## Testing
- npm test -- --runInBand

------
https://chatgpt.com/codex/tasks/task_b_68d263ceb8b08323b47bf14a62355729