### PR TITLE
Ignore manually managed frontend assets

### DIFF
--- a/frontend/src/assets/.gitignore
+++ b/frontend/src/assets/.gitignore
@@ -1,0 +1,3 @@
+# Ignore manually supplied assets (e.g., bvmw-logo.png)
+*
+!.gitignore


### PR DESCRIPTION
## Summary
- add an assets directory placeholder with a .gitignore file
- ensure manually supplied files like the BVMW logo remain untracked while keeping the import path usable

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68d27005fa6c8323a045124606e15513