### PR TITLE
Preserve zero values for report numeric fields

### DIFF
--- a/backend/routes/reports.js
+++ b/backend/routes/reports.js
@@ -181,9 +181,9 @@ router.post('/', reportValidationRules, async (req, res) => {
     }
 
     // Bei anonymen Meldungen Kontaktdaten auf null setzen
-    const finalReporterName = is_anonymous ? null : (reporter_name || null);
-    const finalReporterCompany = is_anonymous ? null : (reporter_company || null);
-    const finalReporterEmail = is_anonymous ? null : (reporter_email || null);
+    const finalReporterName = is_anonymous ? null : (reporter_name ?? null);
+    const finalReporterCompany = is_anonymous ? null : (reporter_company ?? null);
+    const finalReporterEmail = is_anonymous ? null : (reporter_email ?? null);
 
     // Meldung in die Datenbank einfügen
     const [result] = await db.query(
@@ -195,14 +195,14 @@ router.post('/', reportValidationRules, async (req, res) => {
         title,
         description,
         category_id,
-        time_spent || null,
-        costs || null,
-        affected_employees || null,
+        time_spent ?? null,
+        costs ?? null,
+        affected_employees ?? null,
         finalReporterName,
         finalReporterCompany,
         finalReporterEmail,
-        wz_category_key || null,
-        is_anonymous || false,
+        wz_category_key ?? null,
+        is_anonymous ?? false,
         'pending'
       ]
     );

--- a/backend/tests/reports.test.js
+++ b/backend/tests/reports.test.js
@@ -58,6 +58,36 @@ describe('POST /api/reports', () => {
     expect(db.query.mock.calls[1][1][9]).toBe('A');
     expect(db.query.mock.calls[1][1][11]).toBe('pending');
   });
+
+  it('keeps zero values for numeric fields', async () => {
+    db.query.mockResolvedValueOnce([[{ id: 1 }]]);
+    db.query.mockResolvedValueOnce([{ insertId: 43 }]);
+    const zeroReport = {
+      ...basePendingReport,
+      id: 43,
+      time_spent: 0,
+      costs: 0,
+      affected_employees: 0
+    };
+    db.query.mockResolvedValueOnce([[zeroReport]]);
+
+    const res = await request(app).post('/api/reports').send({
+      title: 'Test',
+      description: 'Desc',
+      category_id: 1,
+      time_spent: 0,
+      costs: 0,
+      affected_employees: 0,
+      wz_category_key: 'A'
+    });
+
+    expect(res.statusCode).toBe(201);
+    expect(res.body).toEqual(zeroReport);
+    const insertParams = db.query.mock.calls[1][1];
+    expect(insertParams[3]).toBe(0);
+    expect(insertParams[4]).toBe(0);
+    expect(insertParams[5]).toBe(0);
+  });
 });
 
 describe('GET /api/reports', () => {


### PR DESCRIPTION
## Summary
- use nullish coalescing for numeric and optional report fields so falsy values like 0 persist
- keep reporter details intact unless truly missing and ensure wz category/is_anonymous defaulting only on nullish inputs
- add a regression test verifying zero values survive insertion

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68d28aefeea08323be5ee7110fc235e5