### PR TITLE
Add moderator report listing and tests

### DIFF
--- a/frontend/src/components/__tests__/ReportList.test.js
+++ b/frontend/src/components/__tests__/ReportList.test.js
@@ -3,7 +3,6 @@ import { render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import axios from 'axios';
 
-let ReportList;
 jest.mock('../CategorySelect', () => () => <div />);
 
 jest.mock('axios', () => ({
@@ -11,10 +10,22 @@ jest.mock('axios', () => ({
   default: { get: jest.fn() },
 }));
 
- beforeEach(() => {
-  jest.resetModules();
+jest.mock('../../AuthContext', () => ({
+  useAuth: jest.fn(),
+}));
+
+const { useAuth } = require('../../AuthContext');
+let ReportList;
+
+beforeAll(() => {
   process.env.REACT_APP_API_BASE_URL = '';
   ReportList = require('../ReportList').default;
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  localStorage.clear();
+  useAuth.mockReturnValue({ user: null });
 });
 
 test('shows comment indicator when has_comments is true', async () => {
@@ -39,4 +50,76 @@ test('shows comment indicator when has_comments is true', async () => {
   await waitFor(() => expect(screen.queryByText('Meldungen werden geladen...')).not.toBeInTheDocument());
   expect(screen.getByTitle('Kommentare vorhanden')).toBeInTheDocument();
   expect(screen.getByText('Test')).toBeInTheDocument();
+});
+
+test('fetches moderator endpoint with auth header when user is moderator', async () => {
+  const token = 'modtoken';
+  localStorage.setItem('authToken', token);
+  useAuth.mockReturnValue({ user: { role: 'moderator' } });
+  axios.get.mockResolvedValueOnce({ data: [
+    {
+      id: 1,
+      title: 'Pending',
+      description: 'Pending Desc',
+      created_at: '2023-01-02',
+      category_id: 1,
+      category_name: 'Cat',
+      vote_count: 0,
+      has_comments: false,
+      status: 'pending',
+    },
+    {
+      id: 2,
+      title: 'Approved',
+      description: 'Approved Desc',
+      created_at: '2023-01-03',
+      category_id: 2,
+      category_name: 'Another',
+      vote_count: 1,
+      has_comments: false,
+      status: 'approved',
+    },
+  ] });
+
+  render(
+    <MemoryRouter>
+      <ReportList />
+    </MemoryRouter>
+  );
+
+  await waitFor(() => expect(axios.get).toHaveBeenCalled());
+  await waitFor(() => expect(screen.queryByText('Meldungen werden geladen...')).not.toBeInTheDocument());
+  expect(axios.get).toHaveBeenCalledWith('/api/reports/pending', {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  expect(screen.getByText('Pending')).toBeInTheDocument();
+  expect(screen.getByText('Approved')).toBeInTheDocument();
+  localStorage.removeItem('authToken');
+});
+
+test('regular users fall back to public endpoint', async () => {
+  axios.get.mockResolvedValueOnce({ data: [
+    {
+      id: 3,
+      title: 'Only Approved',
+      description: 'Desc',
+      created_at: '2023-01-04',
+      category_id: 3,
+      category_name: 'Cat',
+      vote_count: 0,
+      has_comments: false,
+      status: 'approved',
+    },
+  ] });
+
+  render(
+    <MemoryRouter>
+      <ReportList />
+    </MemoryRouter>
+  );
+
+  await waitFor(() => expect(axios.get).toHaveBeenCalledWith('/api/reports', undefined));
+  await waitFor(() => expect(screen.queryByText('Meldungen werden geladen...')).not.toBeInTheDocument());
+  expect(screen.queryByText('Pending')).not.toBeInTheDocument();
+  expect(screen.getByText('Only Approved')).toBeInTheDocument();
 });


### PR DESCRIPTION
## Summary
- add a moderator-protected `/api/reports/pending` endpoint that returns all report statuses with existing fields
- update the ReportList component to call the moderator endpoint with the stored auth token and fall back to the public listing for other users
- expand backend and frontend tests to cover moderator visibility rules and ensure regular users only see approved reports

## Testing
- npm test -- --runTestsByPath tests/reports.test.js
- npm test -- --watchAll=false src/components/__tests__/ReportList.test.js

------
https://chatgpt.com/codex/tasks/task_b_68d29d08482c8323ab4327cf534141d3