### PR TITLE
Add moderator status badges to report list

### DIFF
--- a/frontend/src/components/__tests__/ReportList.test.js
+++ b/frontend/src/components/__tests__/ReportList.test.js
@@ -94,6 +94,8 @@ test('fetches moderator endpoint with auth header when user is moderator', async
   });
   expect(screen.getByText('Pending')).toBeInTheDocument();
   expect(screen.getByText('Approved')).toBeInTheDocument();
+  expect(screen.getByLabelText('Freigabestatus: In Prüfung')).toBeInTheDocument();
+  expect(screen.getByLabelText('Freigabestatus: Freigegeben')).toBeInTheDocument();
   localStorage.removeItem('authToken');
 });
 
@@ -122,4 +124,5 @@ test('regular users fall back to public endpoint', async () => {
   await waitFor(() => expect(screen.queryByText('Meldungen werden geladen...')).not.toBeInTheDocument());
   expect(screen.queryByText('Pending')).not.toBeInTheDocument();
   expect(screen.getByText('Only Approved')).toBeInTheDocument();
+  expect(screen.queryByLabelText(/Freigabestatus/)).not.toBeInTheDocument();
 });


### PR DESCRIPTION
## Summary
- add styled status badge and dot indicator to report cards for moderators and admins
- show translated status labels with accessible tooltip/label based on the report status value
- extend ReportList tests to cover the moderator badge visibility and ensure it stays hidden for regular users

## Testing
- npm test -- ReportList.test.js --watchAll=false

------
https://chatgpt.com/codex/tasks/task_b_68d2abdf4cb083238cae8c55607e7e28