### PR TITLE
Adjust report form inputs to consistent red styling

### DIFF
--- a/frontend/src/components/CategorySelect.js
+++ b/frontend/src/components/CategorySelect.js
@@ -13,7 +13,7 @@ const SelectContainer = styled.div`
 
 const Label = styled.label`
   font-weight: 700;
-  color: #2d2d2d;
+  color: #E30613;
   letter-spacing: 0.01em;
 `;
 
@@ -21,18 +21,18 @@ const Select = styled.select`
   width: 100%;
   padding: 12px 20px;
   padding-right: 3.5rem;
-  border: none;
+  border: 2px solid #E30613;
   border-radius: 999px;
   font-size: 16px;
   font-weight: 600;
-  background: linear-gradient(135deg, #f7f7fb, #ffffff);
+  background: #fff;
   color: #2d2d2d;
-  box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.08);
-  transition: box-shadow 0.2s ease, transform 0.2s ease, background-color 0.2s ease;
+  box-shadow: 0 8px 18px rgba(227, 6, 19, 0.08);
+  transition: box-shadow 0.2s ease, border-color 0.2s ease, background-color 0.2s ease;
   appearance: none;
   cursor: pointer;
-  background-image: linear-gradient(45deg, transparent 50%, #58585A 50%),
-    linear-gradient(135deg, #58585A 50%, transparent 50%),
+  background-image: linear-gradient(45deg, transparent 50%, #E30613 50%),
+    linear-gradient(135deg, #E30613 50%, transparent 50%),
     linear-gradient(to right, transparent, transparent);
   background-position: calc(100% - 28px) calc(50% - 2px),
     calc(100% - 22px) calc(50% - 2px),
@@ -41,13 +41,14 @@ const Select = styled.select`
   background-repeat: no-repeat;
 
   &:hover {
-    box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.12);
+    box-shadow: 0 10px 22px rgba(227, 6, 19, 0.12);
   }
 
   &:focus {
     outline: none;
-    box-shadow: 0 0 0 3px rgba(0, 159, 227, 0.25);
-    background-color: #fff;
+    border-color: #b20510;
+    box-shadow: 0 0 0 3px rgba(227, 6, 19, 0.18);
+    background-color: #fff5f6;
   }
 `;
 

--- a/frontend/src/components/ReportForm.js
+++ b/frontend/src/components/ReportForm.js
@@ -38,27 +38,47 @@ const Label = styled.label`
 
 const Input = styled.input`
   width: 100%;
-  padding: 10px;
-  border: 1px solid #ccc;
-  border-radius: 4px;
+  padding: 12px 20px;
+  border: 2px solid #E30613;
+  border-radius: 999px;
   font-size: 16px;
-  
+  font-weight: 600;
+  color: #2d2d2d;
+  background-color: #fff;
+  box-shadow: 0 8px 18px rgba(227, 6, 19, 0.08);
+  transition: box-shadow 0.2s ease, border-color 0.2s ease;
+
+  &:hover {
+    box-shadow: 0 10px 22px rgba(227, 6, 19, 0.12);
+  }
+
   &:focus {
-    border-color: #E30613; /* BVMW Rot */
+    border-color: #b20510;
+    box-shadow: 0 0 0 3px rgba(227, 6, 19, 0.18);
     outline: none;
   }
 `;
 
 const TextArea = styled.textarea`
   width: 100%;
-  padding: 10px;
-  border: 1px solid #ccc;
-  border-radius: 4px;
+  padding: 16px 20px;
+  border: 2px solid #E30613;
+  border-radius: 24px;
   font-size: 16px;
+  font-weight: 600;
+  color: #2d2d2d;
+  background-color: #fff;
   min-height: 150px;
-  
+  box-shadow: 0 8px 18px rgba(227, 6, 19, 0.08);
+  transition: box-shadow 0.2s ease, border-color 0.2s ease;
+
+  &:hover {
+    box-shadow: 0 10px 22px rgba(227, 6, 19, 0.12);
+  }
+
   &:focus {
-    border-color: #E30613; /* BVMW Rot */
+    border-color: #b20510;
+    box-shadow: 0 0 0 3px rgba(227, 6, 19, 0.18);
     outline: none;
   }
 `;

--- a/frontend/src/components/WZCategorySelect.js
+++ b/frontend/src/components/WZCategorySelect.js
@@ -4,26 +4,50 @@ import styled from 'styled-components';
 import { API_BASE } from '../api';
 
 const SelectContainer = styled.div`
-  margin-bottom: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  width: 100%;
 `;
 
 const Label = styled.label`
-  display: block;
-  margin-bottom: 8px;
-  font-weight: bold;
+  font-weight: 700;
   color: #E30613;
+  letter-spacing: 0.01em;
 `;
 
 const Select = styled.select`
   width: 100%;
-  padding: 10px;
-  border: 1px solid #ccc;
-  border-radius: 4px;
+  padding: 12px 20px;
+  padding-right: 3.5rem;
+  border: 2px solid #E30613;
+  border-radius: 999px;
   font-size: 16px;
+  font-weight: 600;
+  background: #fff;
+  color: #2d2d2d;
+  box-shadow: 0 8px 18px rgba(227, 6, 19, 0.08);
+  transition: box-shadow 0.2s ease, border-color 0.2s ease, background-color 0.2s ease;
+  appearance: none;
+  cursor: pointer;
+  background-image: linear-gradient(45deg, transparent 50%, #E30613 50%),
+    linear-gradient(135deg, #E30613 50%, transparent 50%),
+    linear-gradient(to right, transparent, transparent);
+  background-position: calc(100% - 28px) calc(50% - 2px),
+    calc(100% - 22px) calc(50% - 2px),
+    calc(100% - 3.2rem) 50%;
+  background-size: 7px 7px, 7px 7px, 1px 50%;
+  background-repeat: no-repeat;
+
+  &:hover {
+    box-shadow: 0 10px 22px rgba(227, 6, 19, 0.12);
+  }
 
   &:focus {
-    border-color: #E30613; /* BVMW Rot */
     outline: none;
+    border-color: #b20510;
+    box-shadow: 0 0 0 3px rgba(227, 6, 19, 0.18);
+    background-color: #fff5f6;
   }
 `;
 


### PR DESCRIPTION
## Summary
- restyle form text inputs and text area with rounded, red-accented styling
- align category and WZ select components to share the same rounded red appearance

## Testing
- npm test -- --watchAll=false *(fails: existing invalid hook call errors in test suite)*

------
https://chatgpt.com/codex/tasks/task_b_68d561a415588323bc094ff4b469fb45