### PR TITLE
Enforce HTTPS usage in production

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,12 @@ JWT_EXPIRES_IN=24h
 `ALLOWED_ORIGINS` legt fest, welche Urspruenge beim Aufruf der API zugelassen sind.
 Mehrere Eintraege koennen komma-getrennt angegeben werden.
 
+**Hinweis zur Bereitstellung:** Im Produktionsbetrieb akzeptiert das Backend nur
+HTTPS-Anfragen. Stellen Sie sicher, dass Ihr Reverse-Proxy oder Load Balancer
+die Verbindung per HTTPS terminiert und den Header `X-Forwarded-Proto`
+weiterleitet. Für lokale Entwicklung und automatisierte Tests (NODE_ENV
+`development` bzw. `test`) bleibt HTTP weiterhin möglich.
+
 ### MySQL-Setup
 
 1. Erstellen Sie eine neue Datenbank:

--- a/backend/app.js
+++ b/backend/app.js
@@ -13,6 +13,19 @@ app.use(express.urlencoded({ extended: true }));
 // Trust proxy für korrekte IP-Adressen
 app.set('trust proxy', true);
 
+// HTTPS erzwingen, wenn verfügbar
+app.use((req, res, next) => {
+  const httpsEnabled = req.secure || req.get('x-forwarded-proto') === 'https';
+  const environment = (process.env.NODE_ENV || '').toLowerCase();
+  const isLocalEnv = ['development', 'test'].includes(environment);
+
+  if (httpsEnabled || isLocalEnv) {
+    return next();
+  }
+
+  res.status(403).json({ message: 'HTTPS ist erforderlich.' });
+});
+
 // CORS-Konfiguration
 const allowedOrigins = (process.env.ALLOWED_ORIGINS || '')
   .split(',')


### PR DESCRIPTION
## Summary
- add middleware that rejects non-HTTPS requests when running outside development or test
- keep local development and automated tests working by allowing HTTP in those environments
- update documentation with deployment note about HTTPS requirement and proxy headers

## Testing
- npm test -- --runInBand

------
https://chatgpt.com/codex/tasks/task_b_68d56943be808323b23f93d4223cc3fa